### PR TITLE
Align tab headings with shared header

### DIFF
--- a/src/components/CalendarTab.js
+++ b/src/components/CalendarTab.js
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
+import { CalendarDays } from 'lucide-react';
 import { db } from '../firebase'; // Assuming this is how you import Firebase
 import { collection, addDoc, getDocs, doc, updateDoc, deleteDoc } from 'firebase/firestore';
 
 // Assuming SidePanel and EventCard are in the same components directory or adjust path
-import SidePanel from './SidePanel'; 
-import EventCard from './EventCard';   
+import SidePanel from './SidePanel';
+import EventCard from './EventCard';
+import TabHeader from './TabHeader';
 
 // Helper: Format Date as YYYY-MM-DD using local time
 const formatDate = (date) => {
@@ -282,8 +284,19 @@ function CalendarTab({ events = [], onEventClick, onEventUpdate }) {
   return (
     <div className="p-4 relative w-full zoom-90">
       <div className="laptop:transform laptop:scale-[0.99] laptop:origin-top">
-      <h2 className="text-2xl font-bold mb-4 text-gray-800">Calendar</h2>
-      
+      <TabHeader
+        icon={<CalendarDays className="h-7 w-7 text-blue-600" />}
+        title="Calendar"
+        actions={
+          <button
+            className="bg-green-500 text-white px-3 py-1.5 rounded text-sm font-medium hover:bg-green-600 whitespace-nowrap transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-50"
+            onClick={() => openNoteModalForAdd(new Date())}
+          >
+            Add Calendar Note
+          </button>
+        }
+      />
+
       <div className="flex flex-wrap items-center justify-between mb-4 bg-gray-50 p-3 rounded-lg gap-4 shadow">
         <div className="flex items-center mr-4 flex-shrink-0">
           <input
@@ -305,12 +318,6 @@ function CalendarTab({ events = [], onEventClick, onEventUpdate }) {
              <span className="text-sm text-gray-700 select-none">Weekly</span>
           </label>
         </div>
-        <button
-          className="bg-green-500 text-white px-3 py-1.5 rounded text-sm font-medium hover:bg-green-600 whitespace-nowrap transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-50"
-          onClick={() => openNoteModalForAdd(new Date())}
-        >
-          Add Calendar Note
-        </button>
       </div>
 
       <div className="flex justify-between items-center mb-4">

--- a/src/components/FinishedTab.js
+++ b/src/components/FinishedTab.js
@@ -1,6 +1,7 @@
 // components/FinishedTab.js
 import React, { useMemo, useState, useEffect } from 'react';
 import EventPreviewCard from './EventPreviewCard';
+import TabHeader from './TabHeader';
 import { Calendar, Filter, ChevronDown, ChevronUp, Search, X } from 'lucide-react';
 
 function FinishedTab({ events, onSelectEvent }) {
@@ -129,20 +130,19 @@ function FinishedTab({ events, onSelectEvent }) {
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm">
       {/* Header with filter toggle */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center">
-          <Calendar className="h-5 w-5 text-indigo-600 mr-2" />
-          <h2 className="text-xl font-bold text-gray-800">Finished Events</h2>
-        </div>
-        
-        <button
-          onClick={() => setShowFilters(!showFilters)}
-          className="flex items-center gap-1 px-2 py-1 text-sm bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 transition-colors"
-        >
-          <Filter className="h-4 w-4" />
-          <span>{showFilters ? 'Hide Filters' : 'Filters'}</span>
-        </button>
-      </div>
+      <TabHeader
+        icon={<Calendar className="h-7 w-7 text-indigo-600" />}
+        title="Finished Events"
+        actions={
+          <button
+            onClick={() => setShowFilters(!showFilters)}
+            className="flex items-center gap-1 px-2 py-1 text-sm bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 transition-colors"
+          >
+            <Filter className="h-4 w-4" />
+            <span>{showFilters ? 'Hide Filters' : 'Filters'}</span>
+          </button>
+        }
+      />
 
       {/* Compact search bar */}
       <div className="mb-4">

--- a/src/components/MaybeTab.js
+++ b/src/components/MaybeTab.js
@@ -1,25 +1,25 @@
 // components/MaybeTab.js
 import React from 'react';
 import EventPreviewCard from './EventPreviewCard';
+import TabHeader from './TabHeader';
 import { PlusCircle, Calendar, Clock } from 'lucide-react';
 
 function MaybeTab({ events, addEvent, onSelectEvent }) {
   return (
     <div className="p-6 bg-white rounded-lg shadow-sm">
-      <div className="flex justify-between items-center mb-6">
-        <div className="flex items-center">
-          <Clock className="h-6 w-6 text-amber-500 mr-2" />
-          <h2 className="text-2xl font-bold text-gray-800">Pending Events</h2>
-        </div>
-        
-        <button
-          onClick={addEvent}
-          className="flex items-center gap-2 bg-gradient-to-r from-amber-500 to-amber-600 text-white px-4 py-2 rounded-lg shadow-sm hover:shadow-md transition-all duration-200"
-        >
-          <PlusCircle className="h-5 w-5" />
-          <span>New Event</span>
-        </button>
-      </div>
+      <TabHeader
+        icon={<Clock className="h-7 w-7 text-amber-500" />}
+        title="Pending Events"
+        actions={
+          <button
+            onClick={addEvent}
+            className="flex items-center gap-2 bg-gradient-to-r from-amber-500 to-amber-600 text-white px-4 py-2 rounded-lg shadow-sm hover:shadow-md transition-all duration-200"
+          >
+            <PlusCircle className="h-5 w-5" />
+            <span>New Event</span>
+          </button>
+        }
+      />
       
       {/* Counter badge */}
       {events.length > 0 && (

--- a/src/components/StatisticsTab.js
+++ b/src/components/StatisticsTab.js
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { Calendar, Filter, BarChart2, LineChart, DollarSign, CheckSquare, Users, MapPin, ChevronDown, TrendingUp, TrendingDown, AlertCircle } from 'lucide-react';
+import TabHeader from './TabHeader';
 
 // --- Reusable UI Components ---
 
@@ -339,13 +340,11 @@ function StatisticsDashboard({ events }) {
 
     return (
         <div className="p-4 sm:p-6 bg-slate-50 min-h-screen">
-            <div className="flex flex-col sm:flex-row items-center justify-between mb-6 gap-3">
-                <div className="flex items-center">
-                    <BarChart2 className="h-8 w-8 text-emerald-600 mr-3" />
-                    <h1 className="text-2xl font-bold text-gray-800">Event Insights Dashboard</h1>
-                </div>
-                {/* Placeholder for global actions like "Export All Stats" if needed */}
-            </div>
+            <TabHeader
+                icon={<BarChart2 className="h-7 w-7 text-emerald-600" />}
+                title="Event Insights Dashboard"
+            />
+            {/* Placeholder for global actions like "Export All Stats" if needed */}
 
             <DateRangeFilter onFilterChange={handleFilterChange} />
 

--- a/src/components/TabHeader.js
+++ b/src/components/TabHeader.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+function TabHeader({ icon, title, actions, className = '', titleClassName = '', as: HeadingTag = 'h1' }) {
+  const containerClasses = [
+    'flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6',
+    className
+  ].filter(Boolean).join(' ');
+
+  const headingClasses = [
+    'text-2xl font-bold text-gray-800',
+    titleClassName
+  ].filter(Boolean).join(' ');
+
+  const actionItems = Array.isArray(actions)
+    ? actions.filter(Boolean)
+    : actions
+      ? [actions]
+      : [];
+
+  return (
+    <div className={containerClasses}>
+      <div className="flex items-center gap-3">
+        {icon && <span className="flex items-center">{icon}</span>}
+        <HeadingTag className={headingClasses}>{title}</HeadingTag>
+      </div>
+      {actionItems.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+          {actionItems.map((action, index) => (
+            <div key={index} className="flex-shrink-0">
+              {action}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TabHeader;

--- a/src/components/UpcomingTab.js
+++ b/src/components/UpcomingTab.js
@@ -1,6 +1,7 @@
 // components/UpcomingTab.js
 import React, { useMemo, useState } from 'react';
 import EventPreviewCard from './EventPreviewCard';
+import TabHeader from './TabHeader';
 import { CalendarClock, CheckCircle, AlertCircle, Search, X } from 'lucide-react';
 
 function UpcomingTab({ events, onSelectEvent }) {
@@ -74,10 +75,10 @@ function UpcomingTab({ events, onSelectEvent }) {
 
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm">
-      <div className="flex items-center mb-4">
-        <CalendarClock className="h-5 w-5 text-[#FF5A5F] mr-2" />
-        <h2 className="text-xl font-bold text-gray-800">Upcoming Events</h2>
-      </div>
+      <TabHeader
+        icon={<CalendarClock className="h-7 w-7 text-[#FF5A5F]" />}
+        title="Upcoming Events"
+      />
 
       <div className="mb-4 relative">
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />


### PR DESCRIPTION
## Summary
- add a shared TabHeader component to standardize tab title layout
- update the Maybe, Upcoming, Finished, Statistics, and Calendar tabs to use the shared header styling

## Testing
- npm test -- --watchAll=false *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7a3484648333962718bac16e42ac