### PR TITLE
Update move buttons with destination labels

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -304,7 +304,11 @@ function App() {
                       onClick={() => handleMoveRightEvent(activeEvent.id)}
                       className="bg-blue-500 text-white w-full px-4 py-2 rounded text-sm hover:bg-blue-600 transition"
                     >
-                      Move Right &rarr;
+                      {activeEvent.status === 'maybe'
+                        ? 'Move to Upcoming Events →'
+                        : activeEvent.status === 'upcoming'
+                          ? 'Move to Finished Events →'
+                          : 'Move Right →'}
                     </button>
                   )}
                   {activeEvent.status !== 'maybe' && ( // Conditionally show Move Left
@@ -312,7 +316,11 @@ function App() {
                       onClick={() => handleMoveLeftEvent(activeEvent.id)}
                       className="bg-blue-500 text-white w-full px-4 py-2 rounded text-sm hover:bg-blue-600 transition"
                     >
-                      &larr; Move Left
+                      {activeEvent.status === 'upcoming'
+                        ? '← Move to Pending Events'
+                        : activeEvent.status === 'finished'
+                          ? '← Move to Upcoming Events'
+                          : '← Move Left'}
                     </button>
                   )}
                   <button


### PR DESCRIPTION
## Summary
- replace the move left/right button labels with status-aware text that mentions the destination event list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf87b903cc8333b57c62f7e8d5c139