### PR TITLE
Make calendar events read-only and shrink attachment uploader

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -210,16 +210,11 @@ function App() {
       case 'statistics':
         return <StatisticsTab events={events} />; // StatisticsTab uses all events
       case 'calendar':
-        // CalendarTab presents a calendar view of every event without enabling in-place editing.
-        // It still needs the unfiltered events array and exposes onEventClick for optional logging hooks.
         return (
           <CalendarTab
             events={events}
+            onEventUpdate={saveEvent}
             onEventClick={(calendarClickedEvent) => {
-              // This callback is for the onEventClick prop in CalendarTab.
-              // Since CalendarTab is now designed to open its own panel,
-              // we do NOT want to call setActiveEvent(calendarClickedEvent) here,
-              // as that would trigger App.js's main SidePanel as well.
               console.log('Event click from CalendarTab. Panel handled by CalendarTab. Event ID:', calendarClickedEvent.id);
             }}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -210,14 +210,11 @@ function App() {
       case 'statistics':
         return <StatisticsTab events={events} />; // StatisticsTab uses all events
       case 'calendar':
-        // CalendarTab now uses its own SidePanel as per previous modifications to CalendarTab.js
-        // It needs all events, not filtered ones.
-        // It needs onEventUpdate to save changes from its internal EventCard.
-        // onEventClick is passed to prevent App.js's main panel from opening due to a calendar click.
+        // CalendarTab presents a calendar view of every event without enabling in-place editing.
+        // It still needs the unfiltered events array and exposes onEventClick for optional logging hooks.
         return (
           <CalendarTab
             events={events}
-            onEventUpdate={saveEvent}
             onEventClick={(calendarClickedEvent) => {
               // This callback is for the onEventClick prop in CalendarTab.
               // Since CalendarTab is now designed to open its own panel,

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -435,12 +435,14 @@ function EventCard(props, ref) {
             <h4 className="text-sm font-semibold text-gray-700 mb-3">Attachments</h4>
             <label
               htmlFor={`fileUpload-${eventId}`}
-              className="relative flex w-full cursor-pointer flex-col items-center justify-center gap-1.5 rounded-xl border-2 border-dashed border-gray-300 bg-white/80 p-3 text-xs text-gray-600 transition-colors hover:border-blue-400 focus-within:border-blue-400 focus-within:ring-2 focus-within:ring-blue-500/30"
+              className="relative flex w-full cursor-pointer flex-wrap items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white/80 px-3 py-2 text-[11px] text-gray-600 transition-colors hover:border-blue-400 focus-within:border-blue-400 focus-within:ring-1 focus-within:ring-blue-500/30"
             >
-              <Paperclip size={20} className="text-blue-400" />
-              <span className="font-medium text-blue-600 text-sm">Upload or drop files</span>
-              <span className="text-[11px] text-gray-500 text-center">
-                Share contracts, layouts, or any helpful documents.
+              <span className="flex items-center gap-1.5 text-blue-600 text-xs font-semibold">
+                <Paperclip size={16} className="text-blue-500" />
+                Add files
+              </span>
+              <span className="text-[10px] text-gray-500 leading-tight text-center">
+                Drag and drop or click to attach supporting docs.
               </span>
               <input
                 id={`fileUpload-${eventId}`}
@@ -452,7 +454,7 @@ function EventCard(props, ref) {
             </label>
 
             {currentEvent.files && currentEvent.files.length > 0 && (
-              <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50/80 p-4">
+              <div className="mt-3 rounded-2xl border border-gray-200 bg-gray-50/80 p-3">
                 <p className="text-sm font-medium text-gray-600 mb-3">Uploaded files</p>
                 <ul className="space-y-2">
                   {currentEvent.files.map((file, index) => (

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -435,11 +435,11 @@ function EventCard(props, ref) {
             <h4 className="text-sm font-semibold text-gray-700 mb-3">Attachments</h4>
             <label
               htmlFor={`fileUpload-${eventId}`}
-              className="relative flex w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-gray-300 bg-white/80 p-6 text-sm text-gray-600 transition-colors hover:border-blue-400 focus-within:border-blue-400 focus-within:ring-2 focus-within:ring-blue-500/40"
+              className="relative flex w-full cursor-pointer flex-col items-center justify-center gap-1.5 rounded-xl border-2 border-dashed border-gray-300 bg-white/80 p-3 text-xs text-gray-600 transition-colors hover:border-blue-400 focus-within:border-blue-400 focus-within:ring-2 focus-within:ring-blue-500/30"
             >
-              <Paperclip size={28} className="text-blue-400" />
-              <span className="font-medium text-blue-600">Upload or drop files here</span>
-              <span className="text-xs text-gray-500">
+              <Paperclip size={20} className="text-blue-400" />
+              <span className="font-medium text-blue-600 text-sm">Upload or drop files</span>
+              <span className="text-[11px] text-gray-500 text-center">
                 Share contracts, layouts, or any helpful documents.
               </span>
               <input


### PR DESCRIPTION
## Summary
- shrink the attachment uploader dropzone to reduce its footprint
- remove the calendar side panel so clicking events only opens the info modal and points users to edit elsewhere

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06ab648d08333951d6c990d51f639