### PR TITLE
Broaden modal overlay and rebalance event grid

### DIFF
--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -6,9 +6,9 @@ import { Paperclip, Calendar as CalendarIcon, Clock, Users, FileText, DollarSign
 // LabeledInput component (remains the same)
 function LabeledInput({ label, type, value, onChange, placeholder, disabled, id, icon, ...rest }) {
   return (
-    <div className="flex flex-col">
-      <label htmlFor={id} className="mb-2 text-sm font-semibold text-gray-700 flex items-center">
-        {icon && React.cloneElement(icon, { size: 14, className: 'mr-2 text-gray-400' })}
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="flex items-center text-sm font-semibold text-slate-600">
+        {icon && React.cloneElement(icon, { size: 14, className: 'mr-2 text-slate-400' })}
         {label}
       </label>
       <input
@@ -18,9 +18,9 @@ function LabeledInput({ label, type, value, onChange, placeholder, disabled, id,
         placeholder={placeholder}
         onChange={onChange}
         disabled={disabled}
-        className={`w-full rounded-xl border border-gray-200 bg-gray-50/70 p-3 text-sm shadow-sm transition-colors duration-150 ease-in-out
-          focus:outline-none focus:ring-2 focus:ring-blue-500/70 focus:border-blue-500/80 focus:bg-white
-          ${disabled ? 'bg-gray-100 cursor-not-allowed text-gray-500 border-gray-200' : 'hover:border-gray-300'}`}
+        className={`w-full rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-700 shadow-sm transition-colors duration-150 ease-in-out
+          focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500/50 placeholder:text-slate-400
+          ${disabled ? 'cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400' : 'hover:border-slate-300'}`}
         {...rest}
       />
     </div>
@@ -33,14 +33,14 @@ function ToggleInput({ label, checked, onChange, id, disabled, description, clas
     <label
       htmlFor={id}
       aria-disabled={disabled}
-      className={`group flex w-full items-center justify-between gap-4 rounded-2xl border border-gray-200 bg-white/70 p-4 shadow-sm transition ${
-        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:border-blue-200'
+      className={`group flex w-full items-start justify-between gap-4 rounded-2xl border border-slate-200 bg-white px-4 py-3.5 shadow-sm transition ${
+        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:border-blue-200 hover:shadow-md'
       } ${className}`}
     >
       <div className="min-w-0">
-        <p className={`text-sm font-semibold ${disabled ? 'text-gray-400' : 'text-gray-700'}`}>{label}</p>
+        <p className={`text-sm font-semibold ${disabled ? 'text-slate-400' : 'text-slate-700'}`}>{label}</p>
         {description && (
-          <p className="mt-1 text-xs text-gray-500">
+          <p className="mt-1 text-xs text-slate-500">
             {description}
           </p>
         )}
@@ -59,7 +59,7 @@ function ToggleInput({ label, checked, onChange, id, disabled, description, clas
           className="peer sr-only"
         />
         <span
-          className="absolute h-6 w-11 rounded-full bg-gray-200 transition peer-checked:bg-blue-500 peer-focus:ring-4 peer-focus:ring-blue-200"
+          className="absolute h-6 w-11 rounded-full bg-slate-200 transition peer-checked:bg-blue-500 peer-focus:ring-4 peer-focus:ring-blue-200"
           aria-hidden="true"
         ></span>
         <span
@@ -68,6 +68,27 @@ function ToggleInput({ label, checked, onChange, id, disabled, description, clas
         ></span>
       </div>
     </label>
+  );
+}
+
+function SectionCard({ icon: Icon, accentColor = 'bg-slate-100 text-slate-500', title, description, children, className = '' }) {
+  return (
+    <section
+      className={`flex h-full flex-col overflow-hidden rounded-[26px] border border-slate-200/80 bg-white/95 shadow-lg shadow-slate-900/5 ${className}`}
+    >
+      <header className="flex items-start gap-3 border-b border-slate-100/80 bg-white/90 px-6 py-5">
+        {Icon && (
+          <span className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl ${accentColor}`}>
+            <Icon size={18} />
+          </span>
+        )}
+        <div className="min-w-0">
+          <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+          {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
+        </div>
+      </header>
+      <div className="flex-1 px-6 py-5">{children}</div>
+    </section>
   );
 }
 
@@ -205,20 +226,14 @@ function EventCard(props, ref) {
   const eventId = currentEvent.id || 'new-event';
 
   return (
-    <div className="space-y-6">
-      <section className="rounded-3xl border border-gray-200 bg-white/85 p-6 shadow-sm">
-        <header className="mb-5 flex items-center gap-3">
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-blue-600">
-            <Info size={20} />
-          </span>
-          <div>
-            <h3 className="text-lg font-semibold text-gray-800">Event Details</h3>
-            <p className="text-sm text-gray-500">
-              Key information about when and where the event takes place.
-            </p>
-          </div>
-        </header>
-        <div className="grid grid-cols-1 gap-x-8 gap-y-6 md:grid-cols-2">
+    <div className="grid items-start gap-6 md:grid-cols-2 lg:grid-cols-[1.15fr_1fr_0.9fr] lg:gap-7 xl:gap-8">
+      <SectionCard
+        icon={Info}
+        accentColor="bg-blue-50 text-blue-600"
+        title="Event Overview"
+        description="Schedule and guest details at a glance."
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
           <LabeledInput
             id={`clientName-${eventId}`}
             label="Client Name"
@@ -243,10 +258,10 @@ function EventCard(props, ref) {
             value={currentEvent.eventDate || ''}
             onChange={(e) => handleChange('eventDate', e.target.value)}
           />
-          <div>
+          <div className="flex flex-col gap-1.5">
             <label
               htmlFor={`buildingArea-${eventId}`}
-              className="mb-2 block text-sm font-semibold text-gray-700"
+              className="text-sm font-semibold text-slate-600"
             >
               Building Area
             </label>
@@ -254,7 +269,7 @@ function EventCard(props, ref) {
               id={`buildingArea-${eventId}`}
               value={currentEvent.buildingArea || ''}
               onChange={(e) => handleChange('buildingArea', e.target.value)}
-              className="w-full rounded-xl border border-gray-200 bg-gray-50/70 p-3 text-sm shadow-sm transition-colors duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500/70 focus:border-blue-500/80 focus:bg-white hover:border-gray-300"
+              className="w-full rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-700 shadow-sm transition-colors duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500/50 hover:border-slate-300"
             >
               <option value="">Select venue</option>
               <option value="Brewhouse">Brewhouse</option>
@@ -286,7 +301,7 @@ function EventCard(props, ref) {
             checked={currentEvent.allDay || false}
             onChange={(e) => handleChange('allDay', e.target.checked)}
             description="Blocks out start and end times for the full day."
-            className="md:col-span-2"
+            className="sm:col-span-2"
           />
           <LabeledInput
             id={`numberOfGuests-${eventId}`}
@@ -299,21 +314,15 @@ function EventCard(props, ref) {
             min="0"
           />
         </div>
-      </section>
+      </SectionCard>
 
-      <section className="rounded-3xl border border-gray-200 bg-white/85 p-6 shadow-sm">
-        <header className="mb-5 flex items-center gap-3">
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
-            <DollarSign size={20} />
-          </span>
-          <div>
-            <h3 className="text-lg font-semibold text-gray-800">Payment Details</h3>
-            <p className="text-sm text-gray-500">
-              Track invoices, deposits, and outstanding balances at a glance.
-            </p>
-          </div>
-        </header>
-        <div className="grid grid-cols-1 gap-x-8 gap-y-6 md:grid-cols-2">
+      <SectionCard
+        icon={DollarSign}
+        accentColor="bg-emerald-50 text-emerald-600"
+        title="Payment Tracking"
+        description="Monitor deposits and outstanding balances."
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
           <LabeledInput
             id={`priceGiven-${eventId}`}
             label="Price Given ($)"
@@ -340,7 +349,7 @@ function EventCard(props, ref) {
             checked={currentEvent.downPaymentReceived || false}
             onChange={(e) => handleChange('downPaymentReceived', e.target.checked)}
             description="Keep track of when the initial payment arrives."
-            className="md:col-span-2"
+            className="sm:col-span-2"
           />
           <LabeledInput
             id={`downPaymentReceivedDate-${eventId}`}
@@ -387,7 +396,7 @@ function EventCard(props, ref) {
             checked={currentEvent.finalPaymentReceived || false}
             onChange={(e) => handleChange('finalPaymentReceived', e.target.checked)}
             description="Confirm when the closing balance has been paid."
-            className="md:col-span-2"
+            className="sm:col-span-2"
           />
           <LabeledInput
             id={`finalPaymentReceivedDate-${eventId}`}
@@ -399,25 +408,20 @@ function EventCard(props, ref) {
             disabled={!currentEvent.finalPaymentReceived}
           />
         </div>
-      </section>
+      </SectionCard>
 
-      <section className="rounded-3xl border border-gray-200 bg-white/85 p-6 shadow-sm">
-        <header className="mb-5 flex items-center gap-3">
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-50 text-purple-600">
-            <FileText size={20} />
-          </span>
-          <div>
-            <h3 className="text-lg font-semibold text-gray-800">Notes & Attachments</h3>
-            <p className="text-sm text-gray-500">
-              Keep everyone aligned with the latest context and paperwork.
-            </p>
-          </div>
-        </header>
-        <div className="space-y-5">
-          <div>
+      <SectionCard
+        icon={FileText}
+        accentColor="bg-violet-50 text-violet-600"
+        title="Notes & Files"
+        description="Capture context and share supporting docs."
+        className="md:col-span-2 lg:col-span-1 lg:row-span-2"
+      >
+        <div className="flex h-full flex-col gap-6">
+          <div className="flex flex-1 flex-col gap-1.5">
             <label
               htmlFor={`notes-${eventId}`}
-              className="mb-2 block text-sm font-semibold text-gray-700"
+              className="text-sm font-semibold text-slate-600"
             >
               Notes
             </label>
@@ -427,22 +431,22 @@ function EventCard(props, ref) {
               placeholder="Add additional details, client requests, or internal notes..."
               value={currentEvent.notes || ''}
               onChange={(e) => handleChange('notes', e.target.value)}
-              className="w-full rounded-2xl border border-gray-200 bg-gray-50/70 p-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500/70 focus:border-blue-500/80 focus:bg-white hover:border-gray-300 min-h-[96px] resize-none"
+              className="min-h-[170px] w-full flex-1 resize-none rounded-2xl border border-slate-200 bg-white px-3.5 py-3 text-sm text-slate-700 shadow-inner transition focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500/50 placeholder:text-slate-400"
               rows="3"
             ></textarea>
           </div>
-          <div>
-            <h4 className="text-sm font-semibold text-gray-700 mb-3">Attachments</h4>
+          <div className="space-y-3">
+            <p className="text-sm font-semibold text-slate-600">Attachments</p>
             <label
               htmlFor={`fileUpload-${eventId}`}
-              className="relative flex w-full cursor-pointer flex-wrap items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white/80 px-3 py-2 text-[11px] text-gray-600 transition-colors hover:border-blue-400 focus-within:border-blue-400 focus-within:ring-1 focus-within:ring-blue-500/30"
+              className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-slate-300 bg-slate-50/70 px-4 py-5 text-center text-sm font-medium text-slate-500 transition-colors hover:border-blue-300 hover:bg-blue-50/50 focus-within:border-blue-300 focus-within:ring-2 focus-within:ring-blue-200/70"
             >
-              <span className="flex items-center gap-1.5 text-blue-600 text-xs font-semibold">
+              <span className="flex items-center gap-2 text-blue-600">
                 <Paperclip size={16} className="text-blue-500" />
                 Add files
               </span>
-              <span className="text-[10px] text-gray-500 leading-tight text-center">
-                Drag and drop or click to attach supporting docs.
+              <span className="text-xs font-normal text-slate-500">
+                Drop documents here or click to browse.
               </span>
               <input
                 id={`fileUpload-${eventId}`}
@@ -454,43 +458,40 @@ function EventCard(props, ref) {
             </label>
 
             {currentEvent.files && currentEvent.files.length > 0 && (
-              <div className="mt-3 rounded-2xl border border-gray-200 bg-gray-50/80 p-3">
-                <p className="text-sm font-medium text-gray-600 mb-3">Uploaded files</p>
-                <ul className="space-y-2">
-                  {currentEvent.files.map((file, index) => (
-                    <li
-                      key={index}
-                      className="group flex items-center justify-between rounded-xl border border-transparent bg-white/80 px-3 py-2 text-sm shadow-sm transition hover:border-blue-200 hover:bg-blue-50/50"
-                    >
-                      <div className="flex min-w-0 items-center gap-2">
-                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100 text-blue-600">
-                          <Paperclip size={16} />
-                        </span>
-                        <a
-                          href={file.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="truncate text-blue-600 hover:text-blue-700 hover:underline"
-                          title={file.name}
-                        >
-                          {file.name}
-                        </a>
-                      </div>
-                      <button
-                        onClick={() => handleDeleteFile(file, index)}
-                        className="ml-3 rounded-lg px-2 py-1 text-xs font-medium text-red-500 transition hover:bg-red-100"
-                        title="Delete this file"
+              <ul className="max-h-64 divide-y divide-slate-200 overflow-y-auto rounded-2xl border border-slate-200 bg-white">
+                {currentEvent.files.map((file, index) => (
+                  <li
+                    key={index}
+                    className="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600 transition hover:bg-blue-50/40"
+                  >
+                    <div className="flex min-w-0 items-center gap-3">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-blue-100 text-blue-600">
+                        <Paperclip size={16} />
+                      </span>
+                      <a
+                        href={file.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="truncate font-medium text-blue-600 hover:text-blue-700 hover:underline"
+                        title={file.name}
                       >
-                        Delete
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+                        {file.name}
+                      </a>
+                    </div>
+                    <button
+                      onClick={() => handleDeleteFile(file, index)}
+                      className="rounded-full border border-transparent px-3 py-1 text-xs font-semibold text-rose-500 transition hover:border-rose-100 hover:bg-rose-50"
+                      title="Delete this file"
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         </div>
-      </section>
+      </SectionCard>
     </div>
   );
 }

--- a/src/components/SidePanel.js
+++ b/src/components/SidePanel.js
@@ -5,78 +5,73 @@ import { X } from 'lucide-react'; // Import X icon from lucide-react
 
 function SidePanel({ isOpen, onClose, children, title = 'Details' }) {
   const [isVisible, setIsVisible] = useState(isOpen);
-  
-  // Handle open/close states
+
   useEffect(() => {
     if (isOpen) {
       setIsVisible(true);
-      // Prevent scrolling on the body when the panel is open
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.overflow = 'auto';
+      setIsVisible(false);
     }
-    
-    // Cleanup: restore scrolling on unmount
+
     return () => {
       document.body.style.overflow = 'auto';
     };
   }, [isOpen]);
 
-  // Handle the close with animation
   const handleClose = () => {
     setIsVisible(false);
-    // Call onClose only after animation completes
     setTimeout(() => {
       onClose();
-    }, 300); // Make sure this duration matches your animation timing
+    }, 280);
   };
 
   return (
     <AnimatePresence>
       {isVisible && (
-        <>
-          {/* Backdrop with blur effect */}
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8 sm:px-6 sm:py-12"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+        >
           <motion.div
-  className="fixed inset-0 bg-black/50 z-40"
-  initial={{ opacity: 0 }}
-  animate={{ opacity: 1 }}
-  exit={{ opacity: 0 }}
-  onClick={handleClose}
-/>
+            className="absolute inset-0 bg-slate-950/55 backdrop-blur-[2px]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={handleClose}
+          />
 
-          {/* Side Panel */}
           <motion.div
-            className="fixed top-0 right-0 h-full max-w-full w-full md:w-[70%] lg:w-[60%] xl:w-[50%] 2xl:w-[45%] bg-white/90 backdrop-blur-xl shadow-2xl z-50 flex flex-col"
-            initial={{ x: '100%' }}
-            animate={{ x: 0 }}
-            exit={{ x: '100%' }}
-            transition={{ 
-              type: 'spring', 
-              stiffness: 300, 
-              damping: 30,
-              duration: 0.3
-            }}
+            className="relative z-10 w-full max-w-7xl overflow-hidden rounded-[28px] border border-slate-200/70 bg-white/95 shadow-[0_36px_96px_-48px_rgba(15,23,42,0.55)]"
+            initial={{ opacity: 0, y: 36, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 36, scale: 0.97 }}
+            transition={{ type: 'spring', stiffness: 210, damping: 24 }}
+            onClick={(e) => e.stopPropagation()}
           >
-            {/* Header */}
-            <div className="flex items-center justify-between border-b border-gray-100 bg-white/80 px-6 py-4 shadow-sm">
-              <h2 className="text-xl font-semibold text-gray-800">{title}</h2>
+            <div className="flex items-center justify-between border-b border-slate-100/80 bg-white/90 px-6 py-4">
+              <h2 className="text-lg font-semibold text-slate-800">{title}</h2>
               <button
                 onClick={handleClose}
-                className="p-2 rounded-full text-gray-500 hover:bg-gray-100 transition"
+                className="rounded-full p-1.5 text-slate-500 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
                 aria-label="Close panel"
               >
                 <X size={24} />
               </button>
             </div>
 
-            {/* Content - scrollable area */}
-            <div className="flex-1 overflow-y-auto bg-gradient-to-b from-gray-50 via-white to-gray-50">
-              <div className="mx-auto w-full max-w-3xl p-6 md:p-8">
+            <div className="max-h-[calc(100vh-3.5rem)] overflow-y-auto bg-white">
+              <div className="w-full px-6 py-6 sm:px-8 sm:py-8 lg:px-12 lg:py-12 xl:px-16">
                 {children}
               </div>
             </div>
           </motion.div>
-        </>
+        </motion.div>
       )}
     </AnimatePresence>
   );


### PR DESCRIPTION
## Summary
- widen the modal shell with deeper padding and softer shadowing so the overlay feels less cramped
- switch the event card to a three-column layout at large breakpoints and let the notes column span rows for better balance
- limit the attachment list height to avoid overflow while preserving quick access to files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0bb0596348333b2a60d976ed37f67