### PR TITLE
Refine side panel layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -254,6 +254,76 @@ function App() {
             isOpen={!!activeEvent}
             onClose={handleSidePanelClose} // Use the refined handler
             title={activeEvent.eventName || 'Event Details'}
+            footer={
+              <AnimatePresence>
+                {activeEvent && ( // Re-check activeEvent for the motion component
+                  <motion.div
+                    initial={{ y: 100, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    exit={{ y: 100, opacity: 0, transition: { duration: 0.2 } }}
+                    transition={{ type: 'spring', stiffness: 200, damping: 30 }}
+                    className="rounded-2xl border border-gray-200 bg-white/85 p-4 shadow-sm"
+                  >
+                    <div className="flex flex-col gap-5">
+                      <div className="flex flex-wrap items-center justify-center gap-2">
+                        <button
+                          onClick={() => {
+                            if (eventCardRef.current && typeof eventCardRef.current.handleClose === 'function') {
+                              eventCardRef.current.handleClose();
+                            } else {
+                              saveEvent(activeEvent);
+                              setActiveEvent(null);
+                            }
+                          }}
+                          className="rounded-lg bg-green-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-600"
+                        >
+                          Save & Close
+                        </button>
+                        {activeEvent.status !== 'finished' && (
+                          <button
+                            onClick={() => handleMoveRightEvent(activeEvent.id)}
+                            className="rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-600"
+                          >
+                            {activeEvent.status === 'maybe'
+                              ? 'Move to Upcoming Events →'
+                              : activeEvent.status === 'upcoming'
+                                ? 'Move to Finished Events →'
+                                : 'Move Right →'}
+                          </button>
+                        )}
+                        {activeEvent.status !== 'maybe' && (
+                          <button
+                            onClick={() => handleMoveLeftEvent(activeEvent.id)}
+                            className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 transition hover:bg-blue-100"
+                          >
+                            {activeEvent.status === 'upcoming'
+                              ? '← Move to Pending Events'
+                              : activeEvent.status === 'finished'
+                                ? '← Move to Upcoming Events'
+                                : '← Move Left'}
+                          </button>
+                        )}
+                      </div>
+
+                      <div className="flex items-center justify-center gap-3">
+                        <button
+                          onClick={() => deleteEvent(activeEvent.id)}
+                          className="rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-semibold text-red-600 transition hover:bg-red-100"
+                        >
+                          Delete
+                        </button>
+                        <button
+                          onClick={handleSidePanelClose}
+                          className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition hover:text-gray-900"
+                        >
+                          Cancel / Close
+                        </button>
+                      </div>
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            }
           >
             <EventCard
               ref={eventCardRef} // Pass ref to EventCard
@@ -266,76 +336,6 @@ function App() {
               active={true} // This EventCard is active when SidePanel is open
               hideActions={true} // Using external action panel in App.js
             />
-            {/* External action panel as previously designed in App.js */}
-            <AnimatePresence>
-              {activeEvent && ( // Re-check activeEvent for the motion component
-                <motion.div
-                  initial={{ y: 100, opacity: 0 }}
-                  animate={{ y: 0, opacity: 1 }}
-                  exit={{ y: 100, opacity: 0, transition: { duration: 0.2 } }}
-                  transition={{ type: 'spring', stiffness: 200, damping: 30 }}
-                  className="mt-6 rounded-2xl border border-gray-200 bg-white/85 p-4 shadow-sm"
-                  style={{ width: '100%' }}
-                >
-                  <div className="flex flex-col gap-5">
-                    <div className="flex flex-wrap items-center justify-center gap-2">
-                      <button
-                        onClick={() => {
-                          if (eventCardRef.current && typeof eventCardRef.current.handleClose === 'function') {
-                            eventCardRef.current.handleClose();
-                          } else {
-                            saveEvent(activeEvent);
-                            setActiveEvent(null);
-                          }
-                        }}
-                        className="rounded-lg bg-green-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-600"
-                      >
-                        Save & Close
-                      </button>
-                      {activeEvent.status !== 'finished' && (
-                        <button
-                          onClick={() => handleMoveRightEvent(activeEvent.id)}
-                          className="rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-600"
-                        >
-                          {activeEvent.status === 'maybe'
-                            ? 'Move to Upcoming Events →'
-                            : activeEvent.status === 'upcoming'
-                              ? 'Move to Finished Events →'
-                              : 'Move Right →'}
-                        </button>
-                      )}
-                      {activeEvent.status !== 'maybe' && (
-                        <button
-                          onClick={() => handleMoveLeftEvent(activeEvent.id)}
-                          className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 transition hover:bg-blue-100"
-                        >
-                          {activeEvent.status === 'upcoming'
-                            ? '← Move to Pending Events'
-                            : activeEvent.status === 'finished'
-                              ? '← Move to Upcoming Events'
-                              : '← Move Left'}
-                        </button>
-                      )}
-                    </div>
-
-                    <div className="flex items-center justify-center gap-3">
-                      <button
-                        onClick={() => deleteEvent(activeEvent.id)}
-                        className="rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-semibold text-red-600 transition hover:bg-red-100"
-                      >
-                        Delete
-                      </button>
-                      <button
-                        onClick={handleSidePanelClose}
-                        className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition hover:text-gray-900"
-                      >
-                        Cancel / Close
-                      </button>
-                    </div>
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
           </SidePanel>
         </div>
       )}

--- a/src/components/CalendarTab.js
+++ b/src/components/CalendarTab.js
@@ -556,6 +556,28 @@ function CalendarTab({ events = [], onEventClick, onEventUpdate }) {
           isOpen={isEventPanelOpen}
           onClose={handlePanelCloseRequest}
           title={null}
+          footer={
+            <div className="flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={() =>
+                  eventCardRef.current &&
+                  typeof eventCardRef.current.triggerSave === 'function' &&
+                  eventCardRef.current.triggerSave()
+                }
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+              >
+                Save Changes
+              </button>
+              <button
+                type="button"
+                onClick={handlePanelCloseRequest}
+                className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50"
+              >
+                Save &amp; Close
+              </button>
+            </div>
+          }
         >
           <EventCard
             ref={eventCardRef}
@@ -563,22 +585,6 @@ function CalendarTab({ events = [], onEventClick, onEventUpdate }) {
             onSave={handleSaveEventInPanel}
             setActiveEvent={handleEventCardSetActive}
           />
-          <div className="mt-6 flex flex-wrap justify-end gap-3">
-            <button
-              type="button"
-              onClick={() => eventCardRef.current && typeof eventCardRef.current.triggerSave === 'function' && eventCardRef.current.triggerSave()}
-              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
-            >
-              Save Changes
-            </button>
-            <button
-              type="button"
-              onClick={handlePanelCloseRequest}
-              className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50"
-            >
-              Save &amp; Close
-            </button>
-          </div>
         </SidePanel>
       )}
       </div>

--- a/src/components/SidePanel.js
+++ b/src/components/SidePanel.js
@@ -3,9 +3,10 @@ import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react'; // Import X icon from lucide-react
 
-function SidePanel({ isOpen, onClose, children, title = 'Details' }) {
+function SidePanel({ isOpen, onClose, children, title = 'Details', footer = null }) {
   const [isVisible, setIsVisible] = useState(isOpen);
   const hasTitle = Boolean(title);
+  const hasFooter = Boolean(footer);
 
   useEffect(() => {
     if (isOpen) {
@@ -32,14 +33,14 @@ function SidePanel({ isOpen, onClose, children, title = 'Details' }) {
     <AnimatePresence>
       {isVisible && (
         <motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8 sm:px-6 sm:py-12"
+          className="fixed inset-0 z-50 flex items-stretch justify-end lg:px-6 lg:py-12"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
         >
           <motion.div
-            className="absolute inset-0 bg-slate-950/60 backdrop-blur-sm"
+            className="absolute inset-0 bg-slate-950/60"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -48,7 +49,7 @@ function SidePanel({ isOpen, onClose, children, title = 'Details' }) {
           />
 
           <motion.div
-            className="relative z-10 w-full max-w-7xl overflow-hidden rounded-[24px] border border-white/40 bg-gradient-to-br from-white/95 to-white/80 shadow-[0_28px_84px_-48px_rgba(15,23,42,0.6)] backdrop-blur-xl"
+            className="relative z-10 flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-l-3xl border border-slate-200 bg-white shadow-xl"
             initial={{ opacity: 0, y: 32, scale: 0.97 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 32, scale: 0.97 }}
@@ -63,18 +64,24 @@ function SidePanel({ isOpen, onClose, children, title = 'Details' }) {
               <X size={24} />
             </button>
 
-            {hasTitle && (
-              <div className="flex items-center border-b border-white/40 bg-white/70 px-6 py-4 pr-16 backdrop-blur">
-                <h2 className="text-lg font-semibold text-slate-800">{title}</h2>
-              </div>
-            )}
+            <div className="flex h-full flex-col">
+              {hasTitle && (
+                <div className="sticky top-0 z-10 flex items-center border-b border-slate-200 bg-white px-6 py-4 pr-16">
+                  <h2 className="text-lg font-semibold text-slate-800">{title}</h2>
+                </div>
+              )}
 
-            <div className={`max-h-[calc(100vh-3.75rem)] overflow-y-auto bg-transparent ${hasTitle ? '' : 'pt-2'}`}>
               <div
-                className={`w-full bg-white/70 px-6 pb-6 sm:px-8 sm:pb-8 lg:px-12 lg:pb-12 xl:px-16 ${hasTitle ? 'pt-6 sm:pt-8 lg:pt-10' : 'pt-8 sm:pt-10 lg:pt-12'}`}
+                className={`flex-1 overflow-y-auto px-6 pb-6 sm:px-8 sm:pb-8 lg:px-12 lg:pb-12 ${hasTitle ? 'pt-6 sm:pt-8 lg:pt-10' : 'pt-8 sm:pt-10 lg:pt-12'}`}
               >
                 {children}
               </div>
+
+              {hasFooter && (
+                <div className="border-t border-slate-200 bg-white px-6 py-4 sm:px-8 sm:py-6 lg:px-12">
+                  {footer}
+                </div>
+              )}
             </div>
           </motion.div>
         </motion.div>


### PR DESCRIPTION
## Summary
- realign the side panel overlay so the sheet docks to the right with simplified padding
- replace the glassmorphism shell with a white card layout and introduce structured header/body/footer stacking
- update calendar and app side panel usages to pass footer actions into the new sticky layout

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e8669bac8333adf9a9193bdfd514