### PR TITLE
Revamp event previews with modern card layout

### DIFF
--- a/src/components/EventPreviewCard.js
+++ b/src/components/EventPreviewCard.js
@@ -8,7 +8,7 @@ function EventPreviewCard({ event, onClick, highlight }) {
     const date = new Date(year, month - 1, day);
 
     return date.toLocaleDateString('en-US', {
-      month: 'short',
+      month: 'long',
       day: 'numeric',
       year: 'numeric'
     });
@@ -18,7 +18,7 @@ function EventPreviewCard({ event, onClick, highlight }) {
     if (!dateString) return '';
     const [year, month, day] = dateString.split('T')[0].split('-');
     const date = new Date(year, month - 1, day);
-    return date.toLocaleDateString('en-US', { weekday: 'short' });
+    return date.toLocaleDateString('en-US', { weekday: 'long' });
   };
 
   const getInitials = (value) => {
@@ -64,8 +64,6 @@ function EventPreviewCard({ event, onClick, highlight }) {
         ${hasPaymentIssue ? 'border-amber-200' : ''}`}
       onClick={onClick}
     >
-      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#FF5A5F] via-rose-400 to-orange-300" />
-
       <div className="p-4 space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
@@ -100,7 +98,7 @@ function EventPreviewCard({ event, onClick, highlight }) {
           <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
             <User2 className="h-4 w-4 text-[#FF5A5F]" />
             <div className="truncate">
-              <p className="font-medium text-gray-700 truncate">{event.buildingArea || 'TBD'}</p>
+              <p className="font-medium text-gray-700 truncate">{event.buildingArea || 'To be determined'}</p>
               <p className="text-[11px] uppercase tracking-wide">Space</p>
             </div>
           </div>

--- a/src/components/EventPreviewCard.js
+++ b/src/components/EventPreviewCard.js
@@ -41,20 +41,15 @@ function EventPreviewCard({ event, onClick, highlight }) {
       ? 'Final payment due'
       : null;
 
-  const chipColor =
-    event.status === 'finished'
-      ? 'bg-emerald-100 text-emerald-700'
-      : event.status === 'upcoming'
-        ? 'bg-blue-100 text-blue-700'
-        : 'bg-amber-100 text-amber-700';
+  const chipColor = 'bg-slate-100 text-slate-600';
 
   const formattedTotal = formatCurrency(event.grandTotal || event.priceGiven);
 
   return (
     <div
-      className={`relative overflow-hidden rounded-xl border border-gray-200 bg-white/80 backdrop-blur transition-all duration-300 cursor-pointer shadow-sm hover:shadow-md hover:-translate-y-0.5
-        ${highlight ? 'ring-2 ring-offset-2 ring-[#FF5A5F]/40' : ''}
-        ${hasPaymentIssue ? 'border-amber-200' : ''}`}
+      className={`relative overflow-hidden rounded-xl border border-slate-200 bg-white transition-all duration-300 cursor-pointer shadow-sm hover:shadow-md hover:-translate-y-0.5
+        ${highlight ? 'ring-2 ring-offset-2 ring-sky-400/30' : ''}
+        ${hasPaymentIssue ? 'border-sky-200' : ''}`}
       onClick={onClick}
     >
       <div className="p-4 space-y-3">
@@ -74,34 +69,34 @@ function EventPreviewCard({ event, onClick, highlight }) {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-3 text-xs text-gray-500 sm:grid-cols-3">
-          <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
-            <Calendar className="h-4 w-4 text-[#FF5A5F]" />
+        <div className="grid grid-cols-1 gap-3 text-xs text-slate-500 sm:grid-cols-3">
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+            <Calendar className="h-4 w-4 text-sky-500" />
             <div>
-              <p className="font-medium text-gray-700">{formatDate(event.eventDate)}</p>
-              <p className="text-[11px] uppercase tracking-wide">{formatWeekday(event.eventDate)}</p>
+              <p className="font-medium text-slate-700">{formatDate(event.eventDate)}</p>
+              <p className="text-[11px] uppercase tracking-wide text-slate-400">{formatWeekday(event.eventDate)}</p>
             </div>
           </div>
 
-          <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
-            <User2 className="h-4 w-4 text-[#FF5A5F]" />
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+            <User2 className="h-4 w-4 text-sky-500" />
             <div className="truncate">
-              <p className="font-medium text-gray-700 truncate">{event.buildingArea || 'To be determined'}</p>
-              <p className="text-[11px] uppercase tracking-wide">Space</p>
+              <p className="font-medium text-slate-700 truncate">{event.buildingArea || 'To be determined'}</p>
+              <p className="text-[11px] uppercase tracking-wide text-slate-400">Space</p>
             </div>
           </div>
 
-          <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
-            <DollarSign className="h-4 w-4 text-[#FF5A5F]" />
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+            <DollarSign className="h-4 w-4 text-sky-500" />
             <div>
-              <p className="font-medium text-gray-700">{formattedTotal || 'Not set'}</p>
-              <p className="text-[11px] uppercase tracking-wide">Total</p>
+              <p className="font-medium text-slate-700">{formattedTotal || 'Not set'}</p>
+              <p className="text-[11px] uppercase tracking-wide text-slate-400">Total</p>
             </div>
           </div>
         </div>
 
         {hasPaymentIssue && paymentLabel && (
-          <div className="flex items-center justify-between rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
+          <div className="flex items-center justify-between rounded-lg border border-sky-100 bg-sky-50 px-3 py-2 text-xs text-sky-700">
             <div className="flex items-center gap-2 font-medium">
               <DollarSign className="h-3.5 w-3.5" />
               {paymentLabel}

--- a/src/components/EventPreviewCard.js
+++ b/src/components/EventPreviewCard.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import { DollarSign, Calendar } from 'lucide-react';
+import { DollarSign, Calendar, ClipboardList, User2 } from 'lucide-react';
 
 function EventPreviewCard({ event, onClick, highlight }) {
-  // Format date to be more readable
   const formatDate = (dateString) => {
     if (!dateString) return 'No Date';
     const [year, month, day] = dateString.split('T')[0].split('-');
     const date = new Date(year, month - 1, day);
-    
+
     return date.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
@@ -15,42 +14,113 @@ function EventPreviewCard({ event, onClick, highlight }) {
     });
   };
 
-  // Check payment status
+  const formatWeekday = (dateString) => {
+    if (!dateString) return '';
+    const [year, month, day] = dateString.split('T')[0].split('-');
+    const date = new Date(year, month - 1, day);
+    return date.toLocaleDateString('en-US', { weekday: 'short' });
+  };
+
+  const getInitials = (value) => {
+    if (!value) return 'EV';
+    const parts = value.trim().split(' ').filter(Boolean);
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+  };
+
+  const formatCurrency = (value) => {
+    if (!value || Number.isNaN(Number(value))) return null;
+    const numberValue = typeof value === 'string' ? Number(value) : value;
+    if (!Number.isFinite(numberValue)) return null;
+    return numberValue.toLocaleString('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    });
+  };
+
   const needsDownPayment = event.downPaymentRequired > 0 && !event.downPaymentReceived;
   const needsFinalPayment = event.grandTotal > 0 && !event.finalPaymentReceived;
   const hasPaymentIssue = needsDownPayment || needsFinalPayment;
+  const paymentLabel = needsDownPayment
+    ? 'Down payment due'
+    : needsFinalPayment
+      ? 'Final payment due'
+      : null;
+
+  const chipColor =
+    event.status === 'finished'
+      ? 'bg-emerald-100 text-emerald-700'
+      : event.status === 'upcoming'
+        ? 'bg-blue-100 text-blue-700'
+        : 'bg-amber-100 text-amber-700';
+
+  const formattedTotal = formatCurrency(event.grandTotal || event.priceGiven);
 
   return (
     <div
-      className={`laptop:p-2 p-3 bg-white rounded-lg shadow hover:shadow-md cursor-pointer transition 
-      ${highlight ? 'border-l-4 border-blue-500' : ''} 
-      ${hasPaymentIssue ? 'border-r-2 border-r-amber-400' : ''}`}
+      className={`relative overflow-hidden rounded-xl border border-gray-200 bg-white/80 backdrop-blur transition-all duration-300 cursor-pointer shadow-sm hover:shadow-md hover:-translate-y-0.5
+        ${highlight ? 'ring-2 ring-offset-2 ring-[#FF5A5F]' : ''}
+        ${hasPaymentIssue ? 'border-amber-200' : ''}`}
       onClick={onClick}
     >
-      <div className="flex justify-between items-center">
-        <h3 className="font-semibold text-gray-800 truncate laptop:text-sm text-base">
-          {event.clientName || 'No Client'}
-        </h3>
-        {hasPaymentIssue && (
-          <span className="text-amber-500" title="Payment needed">
-            <DollarSign size={16} className="laptop:w-4 laptop:h-4" />
-          </span>
-        )}
-      </div>
-      
-      <p className="text-gray-600 laptop:text-xs text-sm truncate">
-        {event.eventName || 'No Event Name'}
-      </p>
-      
-      <div className="flex items-center justify-between mt-1 laptop:text-xs text-sm">
-        <div className="flex items-center text-gray-500">
-          <Calendar size={14} className="mr-1 laptop:w-3 laptop:h-3" />
-          {formatDate(event.eventDate)}
+      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#FF5A5F] via-rose-400 to-orange-300" />
+
+      <div className="p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#FF5A5F]/15 to-orange-200/40 text-[#FF5A5F] font-semibold">
+              {getInitials(event.clientName || event.eventName)}
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-gray-900 truncate">
+                {event.clientName || 'No Client'}
+              </p>
+              <p className="text-xs text-gray-500 truncate flex items-center gap-1">
+                <ClipboardList className="h-3.5 w-3.5 text-gray-400" />
+                {event.eventName || 'No Event Name'}
+              </p>
+            </div>
+          </div>
+
+          <div className={`hidden sm:flex items-center gap-2 text-xs font-medium ${chipColor} px-3 py-1 rounded-full whitespace-nowrap`}>
+            {event.status ? event.status.charAt(0).toUpperCase() + event.status.slice(1) : 'Event'}
+          </div>
         </div>
-        
-        {hasPaymentIssue && (
-          <div className="text-amber-500 font-medium laptop:text-xs text-sm">
-            {needsDownPayment ? 'Down payment due' : 'Final payment due'}
+
+        <div className="grid grid-cols-1 gap-3 text-xs text-gray-500 sm:grid-cols-3">
+          <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
+            <Calendar className="h-4 w-4 text-[#FF5A5F]" />
+            <div>
+              <p className="font-medium text-gray-700">{formatDate(event.eventDate)}</p>
+              <p className="text-[11px] uppercase tracking-wide">{formatWeekday(event.eventDate)}</p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
+            <User2 className="h-4 w-4 text-[#FF5A5F]" />
+            <div className="truncate">
+              <p className="font-medium text-gray-700 truncate">{event.buildingArea || 'TBD'}</p>
+              <p className="text-[11px] uppercase tracking-wide">Space</p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
+            <DollarSign className="h-4 w-4 text-[#FF5A5F]" />
+            <div>
+              <p className="font-medium text-gray-700">{formattedTotal || 'Not set'}</p>
+              <p className="text-[11px] uppercase tracking-wide">Total</p>
+            </div>
+          </div>
+        </div>
+
+        {hasPaymentIssue && paymentLabel && (
+          <div className="flex items-center justify-between rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            <div className="flex items-center gap-2 font-medium">
+              <DollarSign className="h-3.5 w-3.5" />
+              {paymentLabel}
+            </div>
+            <span className="font-semibold">Action needed</span>
           </div>
         )}
       </div>

--- a/src/components/EventPreviewCard.js
+++ b/src/components/EventPreviewCard.js
@@ -21,13 +21,6 @@ function EventPreviewCard({ event, onClick, highlight }) {
     return date.toLocaleDateString('en-US', { weekday: 'long' });
   };
 
-  const getInitials = (value) => {
-    if (!value) return 'EV';
-    const parts = value.trim().split(' ').filter(Boolean);
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-    return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
-  };
-
   const formatCurrency = (value) => {
     if (!value || Number.isNaN(Number(value))) return null;
     const numberValue = typeof value === 'string' ? Number(value) : value;
@@ -60,25 +53,20 @@ function EventPreviewCard({ event, onClick, highlight }) {
   return (
     <div
       className={`relative overflow-hidden rounded-xl border border-gray-200 bg-white/80 backdrop-blur transition-all duration-300 cursor-pointer shadow-sm hover:shadow-md hover:-translate-y-0.5
-        ${highlight ? 'ring-2 ring-offset-2 ring-[#FF5A5F]' : ''}
+        ${highlight ? 'ring-2 ring-offset-2 ring-[#FF5A5F]/40' : ''}
         ${hasPaymentIssue ? 'border-amber-200' : ''}`}
       onClick={onClick}
     >
       <div className="p-4 space-y-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex items-center gap-3 min-w-0">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#FF5A5F]/15 to-orange-200/40 text-[#FF5A5F] font-semibold">
-              {getInitials(event.clientName || event.eventName)}
-            </div>
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-gray-900 truncate">
-                {event.clientName || 'No Client'}
-              </p>
-              <p className="text-xs text-gray-500 truncate flex items-center gap-1">
-                <ClipboardList className="h-3.5 w-3.5 text-gray-400" />
-                {event.eventName || 'No Event Name'}
-              </p>
-            </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm font-semibold text-gray-900 truncate">
+              {event.clientName || 'No Client'}
+            </p>
+            <p className="text-xs text-gray-500 truncate flex items-center gap-1">
+              <ClipboardList className="h-3.5 w-3.5 text-gray-400" />
+              {event.eventName || 'No Event Name'}
+            </p>
           </div>
 
           <div className={`hidden sm:flex items-center gap-2 text-xs font-medium ${chipColor} px-3 py-1 rounded-full whitespace-nowrap`}>

--- a/src/components/EventPreviewCard.js
+++ b/src/components/EventPreviewCard.js
@@ -41,25 +41,25 @@ function EventPreviewCard({ event, onClick, highlight }) {
       ? 'Final payment due'
       : null;
 
-  const chipColor = 'bg-slate-100 text-slate-600';
+  const chipColor = 'bg-indigo-500/10 text-indigo-600';
 
   const formattedTotal = formatCurrency(event.grandTotal || event.priceGiven);
 
   return (
     <div
-      className={`relative overflow-hidden rounded-xl border border-slate-200 bg-white transition-all duration-300 cursor-pointer shadow-sm hover:shadow-md hover:-translate-y-0.5
-        ${highlight ? 'ring-2 ring-offset-2 ring-sky-400/30' : ''}
-        ${hasPaymentIssue ? 'border-sky-200' : ''}`}
+      className={`relative overflow-hidden rounded-xl border border-slate-200 bg-white transition-all duration-300 cursor-pointer shadow-sm hover:shadow-lg hover:-translate-y-0.5
+        ${highlight ? 'ring-2 ring-offset-2 ring-indigo-500/25' : ''}
+        ${hasPaymentIssue ? 'border-rose-200' : ''}`}
       onClick={onClick}
     >
       <div className="p-4 space-y-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 space-y-1">
-            <p className="text-sm font-semibold text-gray-900 truncate">
+            <p className="text-sm font-semibold text-slate-900 truncate">
               {event.clientName || 'No Client'}
             </p>
-            <p className="text-xs text-gray-500 truncate flex items-center gap-1">
-              <ClipboardList className="h-3.5 w-3.5 text-gray-400" />
+            <p className="flex items-center gap-1 text-xs text-slate-500 truncate">
+              <ClipboardList className="h-3.5 w-3.5 text-slate-400" />
               {event.eventName || 'No Event Name'}
             </p>
           </div>
@@ -70,33 +70,33 @@ function EventPreviewCard({ event, onClick, highlight }) {
         </div>
 
         <div className="grid grid-cols-1 gap-3 text-xs text-slate-500 sm:grid-cols-3">
-          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-            <Calendar className="h-4 w-4 text-sky-500" />
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-900/5 px-3 py-2">
+            <Calendar className="h-4 w-4 text-indigo-500" />
             <div>
-              <p className="font-medium text-slate-700">{formatDate(event.eventDate)}</p>
+              <p className="font-medium text-slate-800">{formatDate(event.eventDate)}</p>
               <p className="text-[11px] uppercase tracking-wide text-slate-400">{formatWeekday(event.eventDate)}</p>
             </div>
           </div>
 
-          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-            <User2 className="h-4 w-4 text-sky-500" />
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-900/5 px-3 py-2">
+            <User2 className="h-4 w-4 text-indigo-500" />
             <div className="truncate">
-              <p className="font-medium text-slate-700 truncate">{event.buildingArea || 'To be determined'}</p>
+              <p className="font-medium text-slate-800 truncate">{event.buildingArea || 'To be determined'}</p>
               <p className="text-[11px] uppercase tracking-wide text-slate-400">Space</p>
             </div>
           </div>
 
-          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-            <DollarSign className="h-4 w-4 text-sky-500" />
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-900/5 px-3 py-2">
+            <DollarSign className="h-4 w-4 text-indigo-500" />
             <div>
-              <p className="font-medium text-slate-700">{formattedTotal || 'Not set'}</p>
+              <p className="font-medium text-slate-800">{formattedTotal || 'Not set'}</p>
               <p className="text-[11px] uppercase tracking-wide text-slate-400">Total</p>
             </div>
           </div>
         </div>
 
         {hasPaymentIssue && paymentLabel && (
-          <div className="flex items-center justify-between rounded-lg border border-sky-100 bg-sky-50 px-3 py-2 text-xs text-sky-700">
+          <div className="flex items-center justify-between rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-600">
             <div className="flex items-center gap-2 font-medium">
               <DollarSign className="h-3.5 w-3.5" />
               {paymentLabel}

--- a/src/components/FinishedTab.js
+++ b/src/components/FinishedTab.js
@@ -138,12 +138,12 @@ function FinishedTab({ events, onSelectEvent }) {
     <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       {/* Header with filter toggle */}
       <TabHeader
-        icon={<Calendar className="h-7 w-7 text-sky-500" />}
+        icon={<Calendar className="h-7 w-7 text-indigo-500" />}
         title="Finished Events"
         actions={
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className="flex items-center gap-1 rounded-lg border border-sky-100 bg-sky-50 px-2 py-1 text-sm text-sky-600 transition-colors hover:bg-sky-100"
+            className="flex items-center gap-1 rounded-lg border border-indigo-200 bg-indigo-50 px-2 py-1 text-sm text-indigo-600 transition-colors hover:bg-indigo-100"
           >
             <Filter className="h-4 w-4" />
             <span>{showFilters ? 'Hide Filters' : 'Filters'}</span>
@@ -154,18 +154,18 @@ function FinishedTab({ events, onSelectEvent }) {
       {/* Compact search bar */}
       <div className="mb-6">
         <div className="relative">
-          <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 transform text-gray-400" />
+          <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 transform text-slate-400" />
           <input
             type="text"
             placeholder="Search in finished events..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full rounded-full border border-slate-200 bg-white py-2 pl-11 pr-11 text-sm focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100"
+            className="w-full rounded-full border border-slate-200 bg-white py-2 pl-11 pr-11 text-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
           />
           {searchQuery && (
             <button
               onClick={() => setSearchQuery('')}
-              className="absolute right-4 top-1/2 -translate-y-1/2 transform text-gray-400 transition hover:text-gray-600"
+              className="absolute right-4 top-1/2 -translate-y-1/2 transform text-slate-400 transition hover:text-slate-600"
             >
               <X className="h-4 w-4" />
             </button>
@@ -181,7 +181,7 @@ function FinishedTab({ events, onSelectEvent }) {
             {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
               <button
                 onClick={clearFilters}
-                className="text-xs text-sky-600 transition-colors hover:text-sky-700"
+                className="text-xs text-indigo-600 transition-colors hover:text-indigo-700"
               >
                 Clear filters
               </button>
@@ -195,7 +195,7 @@ function FinishedTab({ events, onSelectEvent }) {
                 onClick={() => setFilterMode('month')}
                 className={`px-3 py-1 text-xs font-medium rounded-l-lg ${
                   filterMode === 'month'
-                    ? 'bg-sky-500 text-white'
+                    ? 'bg-indigo-600 text-white'
                     : 'border border-slate-200 bg-white text-gray-700 hover:bg-slate-100'
                 }`}
               >
@@ -205,7 +205,7 @@ function FinishedTab({ events, onSelectEvent }) {
                 onClick={() => setFilterMode('range')}
                 className={`px-3 py-1 text-xs font-medium rounded-r-lg ${
                   filterMode === 'range'
-                    ? 'bg-sky-500 text-white'
+                    ? 'bg-indigo-600 text-white'
                     : 'border border-slate-200 bg-white text-gray-700 hover:bg-slate-100'
                 }`}
               >
@@ -222,7 +222,7 @@ function FinishedTab({ events, onSelectEvent }) {
                 <select
                   value={selectedYear}
                   onChange={(e) => setSelectedYear(e.target.value)}
-                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200"
                 >
                   <option value="">All Years</option>
                   {availableYears.map(year => (
@@ -235,7 +235,7 @@ function FinishedTab({ events, onSelectEvent }) {
                 <select
                   value={selectedMonth}
                   onChange={(e) => setSelectedMonth(e.target.value)}
-                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200"
                 >
                   <option value="">All Months</option>
                   {availableMonths.map((month, index) => (
@@ -252,7 +252,7 @@ function FinishedTab({ events, onSelectEvent }) {
                   type="date"
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
-                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200"
                 />
               </div>
               <div>
@@ -261,7 +261,7 @@ function FinishedTab({ events, onSelectEvent }) {
                   type="date"
                   value={endDate}
                   onChange={(e) => setEndDate(e.target.value)}
-                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200"
                 />
               </div>
             </div>
@@ -272,18 +272,18 @@ function FinishedTab({ events, onSelectEvent }) {
       {/* Results Summary - more compact */}
       <div className="mb-6">
         <div className="flex flex-wrap gap-3 text-sm">
-          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-900/5 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-indigo-500">
               <Calendar className="h-5 w-5" />
             </div>
             <div>
               <p className="text-xs uppercase tracking-wide text-slate-500">Archive</p>
-              <p className="font-semibold text-slate-700">{groupedEvents.count} {groupedEvents.count === 1 ? 'event' : 'events'} found</p>
+              <p className="font-semibold text-slate-800">{groupedEvents.count} {groupedEvents.count === 1 ? 'event' : 'events'} found</p>
             </div>
           </div>
 
           {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
-            <div className="flex items-center gap-2 rounded-xl border border-sky-200 bg-sky-50 px-4 py-3 text-xs font-medium text-sky-600">
+            <div className="flex items-center gap-2 rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-3 text-xs font-medium text-indigo-600">
               <Filter className="h-4 w-4" />
               Filters active
             </div>

--- a/src/components/FinishedTab.js
+++ b/src/components/FinishedTab.js
@@ -135,7 +135,7 @@ function FinishedTab({ events, onSelectEvent }) {
   };
 
   return (
-    <div className="p-4 bg-white rounded-lg shadow-sm">
+    <div className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-sm">
       {/* Header with filter toggle */}
       <TabHeader
         icon={<Calendar className="h-7 w-7 text-indigo-600" />}
@@ -152,22 +152,22 @@ function FinishedTab({ events, onSelectEvent }) {
       />
 
       {/* Compact search bar */}
-      <div className="mb-4">
+      <div className="mb-6">
         <div className="relative">
-          <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 transform text-gray-400" />
           <input
             type="text"
             placeholder="Search in finished events..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-8 pr-8 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+            className="w-full rounded-full border border-gray-200 bg-white/80 py-2 pl-11 pr-11 text-sm shadow-inner focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
           />
           {searchQuery && (
-            <button 
+            <button
               onClick={() => setSearchQuery('')}
-              className="absolute right-2 top-1/2 transform -translate-y-1/2"
+              className="absolute right-4 top-1/2 -translate-y-1/2 transform text-gray-400 transition hover:text-gray-600"
             >
-              <X className="h-4 w-4 text-gray-400 hover:text-gray-600" />
+              <X className="h-4 w-4" />
             </button>
           )}
         </div>
@@ -270,24 +270,32 @@ function FinishedTab({ events, onSelectEvent }) {
       )}
 
       {/* Results Summary - more compact */}
-      <div className="mb-3">
-        <div className="bg-indigo-50 px-3 py-1.5 rounded-lg text-sm">
-          <span className="text-indigo-700 font-medium">
-            {groupedEvents.count} {groupedEvents.count === 1 ? 'event' : 'events'} found
-          </span>
+      <div className="mb-6">
+        <div className="flex flex-wrap gap-3 text-sm">
+          <div className="flex items-center gap-3 rounded-xl border border-indigo-200/60 bg-white px-4 py-3 shadow-inner">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-500/10">
+              <Calendar className="h-5 w-5 text-indigo-600" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-indigo-600">Archive</p>
+              <p className="font-semibold text-gray-700">{groupedEvents.count} {groupedEvents.count === 1 ? 'event' : 'events'} found</p>
+            </div>
+          </div>
+
           {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
-            <span className="text-indigo-500 ml-2 text-xs">
-              (filtered)
-            </span>
+            <div className="flex items-center gap-2 rounded-xl border border-indigo-200/40 bg-indigo-50 px-4 py-3 text-xs font-medium text-indigo-600">
+              <Filter className="h-4 w-4" />
+              Filters active
+            </div>
           )}
         </div>
       </div>
 
       {/* Event list - more compact */}
       {groupedEvents.count === 0 ? (
-        <div className="text-center py-6 bg-gray-50 rounded-lg">
-          <Calendar className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-          <p className="text-gray-500 text-sm">No finished events found</p>
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white/70 py-12 text-center">
+          <Calendar className="mx-auto mb-3 h-12 w-12 text-gray-300" />
+          <p className="text-sm text-gray-500">No finished events found</p>
           {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
             <p className="text-xs text-gray-400">Try adjusting your filter settings</p>
           )}
@@ -295,14 +303,14 @@ function FinishedTab({ events, onSelectEvent }) {
       ) : (
         <div className="space-y-3">
           {Object.keys(groupedEvents.groups).sort((a, b) => b - a).map(year => (
-            <div key={year} className="border border-gray-200 rounded-lg overflow-hidden">
+            <div key={year} className="overflow-hidden rounded-2xl border border-gray-200 bg-white">
               <button
                 onClick={() => toggleYearExpand(year)}
-                className="w-full flex items-center justify-between p-2 bg-gray-50 hover:bg-gray-100 transition-colors text-left"
+                className="flex w-full items-center justify-between bg-gray-50 px-4 py-3 text-left transition-colors hover:bg-gray-100"
               >
-                <h3 className="font-medium text-base text-gray-800">{year}</h3>
+                <h3 className="text-base font-semibold text-gray-800">{year}</h3>
                 <div className="flex items-center">
-                  <span className="text-xs text-gray-500 mr-2">
+                  <span className="mr-2 text-xs text-gray-500">
                     {Object.values(groupedEvents.groups[year]).flat().length} events
                   </span>
                   {expandedYears[year] ? (
@@ -314,7 +322,7 @@ function FinishedTab({ events, onSelectEvent }) {
               </button>
               
               {expandedYears[year] && (
-                <div className="p-2 space-y-2">
+                <div className="space-y-3 p-4">
                   {Object.keys(groupedEvents.groups[year])
                     .sort((a, b) => b - a) // Sort months newest first
                     .map(month => {
@@ -323,12 +331,12 @@ function FinishedTab({ events, onSelectEvent }) {
                       const monthExpanded = expandedMonths[year]?.[month];
                       const eventCountLabel = `${eventsForMonth.length} ${eventsForMonth.length === 1 ? 'event' : 'events'}`;
                       return (
-                        <div key={`${year}-${month}`} className="border border-gray-200 rounded-md overflow-hidden bg-white">
+                        <div key={`${year}-${month}`} className="overflow-hidden rounded-2xl border border-gray-200 bg-white">
                           <button
                             onClick={() => toggleMonthExpand(year, month)}
-                            className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-gray-50 transition-colors"
+                            className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-gray-50"
                           >
-                            <span className="font-medium text-sm text-gray-700">{monthNames[monthIndex]} {year}</span>
+                            <span className="text-sm font-semibold text-gray-700">{monthNames[monthIndex]} {year}</span>
                             <div className="flex items-center text-xs text-gray-500">
                               <span className="mr-2">{eventCountLabel}</span>
                               {monthExpanded ? (
@@ -339,7 +347,7 @@ function FinishedTab({ events, onSelectEvent }) {
                             </div>
                           </button>
                           {monthExpanded && (
-                            <div className="p-2 bg-gray-50 space-y-2">
+                            <div className="grid gap-3 bg-gray-50 px-4 py-4 sm:grid-cols-2 xl:grid-cols-3">
                               {eventsForMonth.map(event => (
                                 <EventPreviewCard
                                   key={event.id}

--- a/src/components/FinishedTab.js
+++ b/src/components/FinishedTab.js
@@ -135,15 +135,15 @@ function FinishedTab({ events, onSelectEvent }) {
   };
 
   return (
-    <div className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white via-white to-indigo-50/40 p-6 shadow-sm">
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       {/* Header with filter toggle */}
       <TabHeader
-        icon={<Calendar className="h-7 w-7 text-indigo-600" />}
+        icon={<Calendar className="h-7 w-7 text-sky-500" />}
         title="Finished Events"
         actions={
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className="flex items-center gap-1 px-2 py-1 text-sm bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 transition-colors"
+            className="flex items-center gap-1 rounded-lg border border-sky-100 bg-sky-50 px-2 py-1 text-sm text-sky-600 transition-colors hover:bg-sky-100"
           >
             <Filter className="h-4 w-4" />
             <span>{showFilters ? 'Hide Filters' : 'Filters'}</span>
@@ -160,7 +160,7 @@ function FinishedTab({ events, onSelectEvent }) {
             placeholder="Search in finished events..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full rounded-full border border-gray-200 bg-white/80 py-2 pl-11 pr-11 text-sm shadow-inner focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+            className="w-full rounded-full border border-slate-200 bg-white py-2 pl-11 pr-11 text-sm focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100"
           />
           {searchQuery && (
             <button
@@ -175,13 +175,13 @@ function FinishedTab({ events, onSelectEvent }) {
 
       {/* Expandable filters - more compact */}
       {showFilters && (
-        <div className="mb-4 bg-gray-50 p-3 rounded-lg border border-gray-200 text-sm">
+        <div className="mb-4 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">
           <div className="flex items-center justify-between mb-2">
             <h3 className="font-medium text-gray-700">Filter Options</h3>
             {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
-              <button 
+              <button
                 onClick={clearFilters}
-                className="text-xs text-indigo-600 hover:text-indigo-800"
+                className="text-xs text-sky-600 transition-colors hover:text-sky-700"
               >
                 Clear filters
               </button>
@@ -191,22 +191,22 @@ function FinishedTab({ events, onSelectEvent }) {
           {/* Filter Mode Toggle - more compact */}
           <div className="mb-3">
             <div className="inline-flex rounded-md shadow-sm" role="group">
-              <button 
+              <button
                 onClick={() => setFilterMode('month')}
                 className={`px-3 py-1 text-xs font-medium rounded-l-lg ${
-                  filterMode === 'month' 
-                    ? 'bg-indigo-600 text-white' 
-                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-100'
+                  filterMode === 'month'
+                    ? 'bg-sky-500 text-white'
+                    : 'border border-slate-200 bg-white text-gray-700 hover:bg-slate-100'
                 }`}
               >
                 Month View
               </button>
-              <button 
+              <button
                 onClick={() => setFilterMode('range')}
                 className={`px-3 py-1 text-xs font-medium rounded-r-lg ${
-                  filterMode === 'range' 
-                    ? 'bg-indigo-600 text-white' 
-                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-100'
+                  filterMode === 'range'
+                    ? 'bg-sky-500 text-white'
+                    : 'border border-slate-200 bg-white text-gray-700 hover:bg-slate-100'
                 }`}
               >
                 Date Range
@@ -222,7 +222,7 @@ function FinishedTab({ events, onSelectEvent }) {
                 <select
                   value={selectedYear}
                   onChange={(e) => setSelectedYear(e.target.value)}
-                  className="w-full py-1 text-sm rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
                 >
                   <option value="">All Years</option>
                   {availableYears.map(year => (
@@ -235,7 +235,7 @@ function FinishedTab({ events, onSelectEvent }) {
                 <select
                   value={selectedMonth}
                   onChange={(e) => setSelectedMonth(e.target.value)}
-                  className="w-full py-1 text-sm rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
                 >
                   <option value="">All Months</option>
                   {availableMonths.map((month, index) => (
@@ -248,20 +248,20 @@ function FinishedTab({ events, onSelectEvent }) {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className="block text-xs font-medium text-gray-700 mb-1">From</label>
-                <input 
+                <input
                   type="date"
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
-                  className="w-full py-1 text-sm rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
                 />
               </div>
               <div>
                 <label className="block text-xs font-medium text-gray-700 mb-1">To</label>
-                <input 
+                <input
                   type="date"
                   value={endDate}
                   onChange={(e) => setEndDate(e.target.value)}
-                  className="w-full py-1 text-sm rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                  className="w-full rounded-md border border-slate-200 py-1 text-sm focus:border-sky-400 focus:ring focus:ring-sky-100"
                 />
               </div>
             </div>
@@ -272,18 +272,18 @@ function FinishedTab({ events, onSelectEvent }) {
       {/* Results Summary - more compact */}
       <div className="mb-6">
         <div className="flex flex-wrap gap-3 text-sm">
-          <div className="flex items-center gap-3 rounded-xl border border-indigo-200/60 bg-white px-4 py-3 shadow-inner">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-500/10">
-              <Calendar className="h-5 w-5 text-indigo-600" />
+          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+              <Calendar className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-indigo-600">Archive</p>
-              <p className="font-semibold text-gray-700">{groupedEvents.count} {groupedEvents.count === 1 ? 'event' : 'events'} found</p>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Archive</p>
+              <p className="font-semibold text-slate-700">{groupedEvents.count} {groupedEvents.count === 1 ? 'event' : 'events'} found</p>
             </div>
           </div>
 
           {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
-            <div className="flex items-center gap-2 rounded-xl border border-indigo-200/40 bg-indigo-50 px-4 py-3 text-xs font-medium text-indigo-600">
+            <div className="flex items-center gap-2 rounded-xl border border-sky-200 bg-sky-50 px-4 py-3 text-xs font-medium text-sky-600">
               <Filter className="h-4 w-4" />
               Filters active
             </div>
@@ -292,21 +292,21 @@ function FinishedTab({ events, onSelectEvent }) {
       </div>
 
       {/* Event list - more compact */}
-      {groupedEvents.count === 0 ? (
-        <div className="rounded-2xl border border-dashed border-gray-200 bg-white/70 py-12 text-center">
-          <Calendar className="mx-auto mb-3 h-12 w-12 text-gray-300" />
-          <p className="text-sm text-gray-500">No finished events found</p>
-          {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
-            <p className="text-xs text-gray-400">Try adjusting your filter settings</p>
-          )}
-        </div>
-      ) : (
+        {groupedEvents.count === 0 ? (
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 py-12 text-center">
+            <Calendar className="mx-auto mb-3 h-12 w-12 text-slate-300" />
+            <p className="text-sm text-slate-500">No finished events found</p>
+            {(selectedYear || selectedMonth || startDate || endDate || searchQuery) && (
+              <p className="text-xs text-slate-400">Try adjusting your filter settings</p>
+            )}
+          </div>
+        ) : (
         <div className="space-y-3">
           {Object.keys(groupedEvents.groups).sort((a, b) => b - a).map(year => (
-            <div key={year} className="overflow-hidden rounded-2xl border border-gray-200 bg-white">
+            <div key={year} className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
               <button
                 onClick={() => toggleYearExpand(year)}
-                className="flex w-full items-center justify-between bg-gray-50 px-4 py-3 text-left transition-colors hover:bg-gray-100"
+                className="flex w-full items-center justify-between bg-slate-50 px-4 py-3 text-left transition-colors hover:bg-slate-100"
               >
                 <h3 className="text-base font-semibold text-gray-800">{year}</h3>
                 <div className="flex items-center">
@@ -331,10 +331,10 @@ function FinishedTab({ events, onSelectEvent }) {
                       const monthExpanded = expandedMonths[year]?.[month];
                       const eventCountLabel = `${eventsForMonth.length} ${eventsForMonth.length === 1 ? 'event' : 'events'}`;
                       return (
-                        <div key={`${year}-${month}`} className="overflow-hidden rounded-2xl border border-gray-200 bg-white">
+                        <div key={`${year}-${month}`} className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
                           <button
                             onClick={() => toggleMonthExpand(year, month)}
-                            className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-gray-50"
+                            className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-slate-50"
                           >
                             <span className="text-sm font-semibold text-gray-700">{monthNames[monthIndex]} {year}</span>
                             <div className="flex items-center text-xs text-gray-500">
@@ -347,7 +347,7 @@ function FinishedTab({ events, onSelectEvent }) {
                             </div>
                           </button>
                           {monthExpanded && (
-                            <div className="grid gap-3 bg-gray-50 px-4 py-4 sm:grid-cols-2 xl:grid-cols-3">
+                            <div className="grid gap-3 bg-slate-50 px-4 py-4 sm:grid-cols-2 xl:grid-cols-3">
                               {eventsForMonth.map(event => (
                                 <EventPreviewCard
                                   key={event.id}
@@ -371,3 +371,4 @@ function FinishedTab({ events, onSelectEvent }) {
 }
 
 export default FinishedTab;
+

--- a/src/components/MaybeTab.js
+++ b/src/components/MaybeTab.js
@@ -8,12 +8,12 @@ function MaybeTab({ events, addEvent, onSelectEvent }) {
   return (
     <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <TabHeader
-        icon={<Clock className="h-7 w-7 text-sky-500" />}
+        icon={<Clock className="h-7 w-7 text-indigo-500" />}
         title="Pending Events"
         actions={
           <button
             onClick={addEvent}
-            className="flex items-center gap-2 rounded-lg bg-sky-500 px-4 py-2 text-white transition-colors duration-200 hover:bg-sky-600"
+            className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-white transition-colors duration-200 hover:bg-indigo-700"
           >
             <PlusCircle className="h-5 w-5" />
             <span>New Event</span>
@@ -24,18 +24,18 @@ function MaybeTab({ events, addEvent, onSelectEvent }) {
       {/* Counter badge */}
       {events.length > 0 && (
         <div className="mb-6 grid gap-3 text-sm sm:grid-cols-2">
-          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-900/5 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-indigo-500">
               <Clock className="h-5 w-5" />
             </div>
             <div>
               <p className="text-xs uppercase tracking-wide text-slate-500">In review</p>
-              <p className="font-semibold text-slate-700">{events.length} pending {events.length === 1 ? 'event' : 'events'}</p>
+              <p className="font-semibold text-slate-800">{events.length} pending {events.length === 1 ? 'event' : 'events'}</p>
             </div>
           </div>
 
-          <div className="hidden sm:flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+          <div className="hidden sm:flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-900/5 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-indigo-500">
               <Calendar className="h-5 w-5" />
             </div>
             <div>
@@ -48,12 +48,12 @@ function MaybeTab({ events, addEvent, onSelectEvent }) {
 
       {/* Event list */}
       {events.length === 0 ? (
-        <div className="rounded-lg bg-slate-50 py-12 text-center">
+        <div className="rounded-lg bg-slate-100 py-12 text-center">
           <Calendar className="mx-auto mb-4 h-12 w-12 text-slate-400" />
           <p className="mb-2 text-slate-500">No pending events</p>
           <button
             onClick={addEvent}
-            className="mt-4 inline-flex items-center font-medium text-sky-600 transition-colors hover:text-sky-700"
+            className="mt-4 inline-flex items-center font-medium text-indigo-600 transition-colors hover:text-indigo-700"
           >
             <PlusCircle className="mr-1 h-4 w-4" />
             Create your first event

--- a/src/components/MaybeTab.js
+++ b/src/components/MaybeTab.js
@@ -6,14 +6,14 @@ import { PlusCircle, Calendar, Clock } from 'lucide-react';
 
 function MaybeTab({ events, addEvent, onSelectEvent }) {
   return (
-    <div className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white via-white to-amber-50/40 p-6 shadow-sm">
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <TabHeader
-        icon={<Clock className="h-7 w-7 text-amber-500" />}
+        icon={<Clock className="h-7 w-7 text-sky-500" />}
         title="Pending Events"
         actions={
           <button
             onClick={addEvent}
-            className="flex items-center gap-2 bg-gradient-to-r from-amber-500 to-amber-600 text-white px-4 py-2 rounded-lg shadow-sm hover:shadow-md transition-all duration-200"
+            className="flex items-center gap-2 rounded-lg bg-sky-500 px-4 py-2 text-white transition-colors duration-200 hover:bg-sky-600"
           >
             <PlusCircle className="h-5 w-5" />
             <span>New Event</span>
@@ -24,23 +24,23 @@ function MaybeTab({ events, addEvent, onSelectEvent }) {
       {/* Counter badge */}
       {events.length > 0 && (
         <div className="mb-6 grid gap-3 text-sm sm:grid-cols-2">
-          <div className="flex items-center gap-3 rounded-xl border border-amber-200/60 bg-white px-4 py-3 shadow-inner">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10">
-              <Clock className="h-5 w-5 text-amber-500" />
+          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+              <Clock className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-amber-500">In review</p>
-              <p className="font-semibold text-gray-700">{events.length} pending {events.length === 1 ? 'event' : 'events'}</p>
+              <p className="text-xs uppercase tracking-wide text-slate-500">In review</p>
+              <p className="font-semibold text-slate-700">{events.length} pending {events.length === 1 ? 'event' : 'events'}</p>
             </div>
           </div>
 
-          <div className="hidden sm:flex items-center gap-3 rounded-xl border border-amber-200/60 bg-white px-4 py-3 shadow-inner">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10">
-              <Calendar className="h-5 w-5 text-amber-500" />
+          <div className="hidden sm:flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+              <Calendar className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-amber-500">Convert quickly</p>
-              <p className="text-sm text-gray-600">Move confirmed bookings to Upcoming</p>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Convert quickly</p>
+              <p className="text-sm text-slate-600">Move confirmed bookings to Upcoming</p>
             </div>
           </div>
         </div>
@@ -48,14 +48,14 @@ function MaybeTab({ events, addEvent, onSelectEvent }) {
 
       {/* Event list */}
       {events.length === 0 ? (
-        <div className="text-center py-12 bg-gray-50 rounded-lg">
-          <Calendar className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <p className="text-gray-500 mb-2">No pending events</p>
+        <div className="rounded-lg bg-slate-50 py-12 text-center">
+          <Calendar className="mx-auto mb-4 h-12 w-12 text-slate-400" />
+          <p className="mb-2 text-slate-500">No pending events</p>
           <button
             onClick={addEvent}
-            className="mt-4 inline-flex items-center text-amber-600 hover:text-amber-700 font-medium"
+            className="mt-4 inline-flex items-center font-medium text-sky-600 transition-colors hover:text-sky-700"
           >
-            <PlusCircle className="h-4 w-4 mr-1" />
+            <PlusCircle className="mr-1 h-4 w-4" />
             Create your first event
           </button>
         </div>

--- a/src/components/MaybeTab.js
+++ b/src/components/MaybeTab.js
@@ -6,7 +6,7 @@ import { PlusCircle, Calendar, Clock } from 'lucide-react';
 
 function MaybeTab({ events, addEvent, onSelectEvent }) {
   return (
-    <div className="p-6 bg-white rounded-lg shadow-sm">
+    <div className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white via-white to-amber-50/40 p-6 shadow-sm">
       <TabHeader
         icon={<Clock className="h-7 w-7 text-amber-500" />}
         title="Pending Events"
@@ -23,9 +23,25 @@ function MaybeTab({ events, addEvent, onSelectEvent }) {
       
       {/* Counter badge */}
       {events.length > 0 && (
-        <div className="mb-6 flex">
-          <div className="bg-amber-50 text-amber-700 px-4 py-2 rounded-full text-sm font-medium">
-            {events.length} pending {events.length === 1 ? 'event' : 'events'}
+        <div className="mb-6 grid gap-3 text-sm sm:grid-cols-2">
+          <div className="flex items-center gap-3 rounded-xl border border-amber-200/60 bg-white px-4 py-3 shadow-inner">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10">
+              <Clock className="h-5 w-5 text-amber-500" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-amber-500">In review</p>
+              <p className="font-semibold text-gray-700">{events.length} pending {events.length === 1 ? 'event' : 'events'}</p>
+            </div>
+          </div>
+
+          <div className="hidden sm:flex items-center gap-3 rounded-xl border border-amber-200/60 bg-white px-4 py-3 shadow-inner">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10">
+              <Calendar className="h-5 w-5 text-amber-500" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-amber-500">Convert quickly</p>
+              <p className="text-sm text-gray-600">Move confirmed bookings to Upcoming</p>
+            </div>
           </div>
         </div>
       )}
@@ -44,7 +60,7 @@ function MaybeTab({ events, addEvent, onSelectEvent }) {
           </button>
         </div>
       ) : (
-        <div className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {events.map(event => (
             <EventPreviewCard
               key={event.id}

--- a/src/components/UpcomingTab.js
+++ b/src/components/UpcomingTab.js
@@ -76,23 +76,23 @@ function UpcomingTab({ events, onSelectEvent }) {
   return (
     <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <TabHeader
-        icon={<CalendarClock className="h-7 w-7 text-sky-500" />}
+        icon={<CalendarClock className="h-7 w-7 text-indigo-500" />}
         title="Upcoming Events"
       />
 
       <div className="relative mb-6">
-        <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 transform text-gray-400" />
+        <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 transform text-slate-400" />
         <input
           type="text"
           placeholder="Search events, people..."
-          className="w-full rounded-full border border-slate-200 bg-white py-2.5 pl-12 pr-12 text-sm focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100"
+          className="w-full rounded-full border border-slate-200 bg-white py-2.5 pl-12 pr-12 text-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
         />
         {searchTerm && (
           <button
             onClick={() => setSearchTerm('')}
-            className="absolute right-4 top-1/2 -translate-y-1/2 transform text-gray-400 transition hover:text-gray-600"
+            className="absolute right-4 top-1/2 -translate-y-1/2 transform text-slate-400 transition hover:text-slate-600"
             aria-label="Clear search"
           >
             <X className="h-5 w-5" />
@@ -102,25 +102,25 @@ function UpcomingTab({ events, onSelectEvent }) {
 
       {(events || []).length > 0 && (
         <div className="mb-6 grid gap-3 text-sm sm:grid-cols-2">
-          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-900/5 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-indigo-500">
               <CheckCircle className="h-5 w-5" />
             </div>
             <div>
               <p className="text-xs uppercase tracking-wide text-slate-500">Pipeline</p>
-              <p className="font-semibold text-slate-700">{(events || []).length} upcoming {(events || []).length === 1 ? 'event' : 'events'}</p>
+              <p className="font-semibold text-slate-800">{(events || []).length} upcoming {(events || []).length === 1 ? 'event' : 'events'}</p>
             </div>
           </div>
 
           {/* Adjusted to use firstEventTitle which checks for eventName first */}
           {firstEventDate && sortedEvents.length > 0 && (
-            <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+            <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-900/5 px-4 py-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-indigo-500">
                 <AlertCircle className="h-5 w-5" />
               </div>
               <div className="min-w-0">
                 <p className="text-xs uppercase tracking-wide text-slate-500">Next up</p>
-                <p className="font-semibold text-sky-600 truncate">
+                <p className="font-semibold text-indigo-600 truncate">
                   {nextEventCountdown}: {firstEventTitle}
                 </p>
               </div>
@@ -130,7 +130,7 @@ function UpcomingTab({ events, onSelectEvent }) {
       )}
 
       {filteredEvents.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 py-12 text-center">
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-100 py-12 text-center">
           <CalendarClock className="mx-auto mb-3 h-12 w-12 text-slate-300" />
           <p className="text-sm text-slate-500">{searchTerm ? "No events match your search." : "No upcoming events"}</p>
         </div>
@@ -139,7 +139,7 @@ function UpcomingTab({ events, onSelectEvent }) {
           {Object.entries(groupedEvents).map(([monthYear, monthEvents]) => (
             <div key={monthYear}>
               <h3 className="mb-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                <span className="h-1.5 w-1.5 rounded-full bg-sky-400" />
+                <span className="h-1.5 w-1.5 rounded-full bg-indigo-500" />
                 {monthYear}
               </h3>
               <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/src/components/UpcomingTab.js
+++ b/src/components/UpcomingTab.js
@@ -74,25 +74,25 @@ function UpcomingTab({ events, onSelectEvent }) {
   }, [firstEventDate]);
 
   return (
-    <div className="p-4 bg-white rounded-lg shadow-sm">
+    <div className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white via-white to-gray-50 p-6 shadow-sm">
       <TabHeader
         icon={<CalendarClock className="h-7 w-7 text-[#FF5A5F]" />}
         title="Upcoming Events"
       />
 
-      <div className="mb-4 relative">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+      <div className="relative mb-6">
+        <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 transform text-gray-400" />
         <input
           type="text"
           placeholder="Search events, people..."
-          className="w-full p-2 pl-10 border border-gray-300 rounded-md focus:ring-1 focus:ring-[#FF5A5F] focus:border-[#FF5A5F]"
+          className="w-full rounded-full border border-gray-200 bg-white/80 py-2.5 pl-12 pr-12 text-sm shadow-inner focus:border-[#FF5A5F] focus:outline-none focus:ring-2 focus:ring-[#FF5A5F]/30"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
         />
         {searchTerm && (
           <button
             onClick={() => setSearchTerm('')}
-            className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
+            className="absolute right-4 top-1/2 -translate-y-1/2 transform text-gray-400 transition hover:text-gray-600"
             aria-label="Clear search"
           >
             <X className="h-5 w-5" />
@@ -101,22 +101,28 @@ function UpcomingTab({ events, onSelectEvent }) {
       </div>
 
       {(events || []).length > 0 && (
-        <div className="mb-4 flex gap-3 text-sm">
-          <div className="flex-1 bg-[#FFF5F7] p-3 rounded-lg border-l-[3px] border-[#FF5A5F]">
-            <div className="flex items-center">
-              <CheckCircle className="h-4 w-4 text-[#FF5A5F] mr-1" />
-              <span className="font-medium">{(events || []).length} upcoming {(events || []).length === 1 ? 'event' : 'events'}</span>
+        <div className="mb-6 grid gap-3 text-sm sm:grid-cols-2">
+          <div className="flex items-center gap-3 rounded-xl border border-[#FF5A5F]/20 bg-[#FFF5F7] px-4 py-3 shadow-inner">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[#FF5A5F]/10">
+              <CheckCircle className="h-5 w-5 text-[#FF5A5F]" />
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-[#FF5A5F]">Pipeline</p>
+              <p className="font-semibold text-gray-700">{(events || []).length} upcoming {(events || []).length === 1 ? 'event' : 'events'}</p>
             </div>
           </div>
-          
+
           {/* Adjusted to use firstEventTitle which checks for eventName first */}
           {firstEventDate && sortedEvents.length > 0 && (
-            <div className="flex-1 bg-[#FFF5F7] p-3 rounded-lg border-l-[3px] border-[#FF5A5F]">
-              <div className="flex items-center">
-                <AlertCircle className="h-4 w-4 text-[#FF5A5F] mr-1" />
-                <span className="font-medium text-[#FF5A5F] truncate">
+            <div className="flex items-center gap-3 rounded-xl border border-[#FF5A5F]/20 bg-[#FFF5F7] px-4 py-3 shadow-inner">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[#FF5A5F]/10">
+                <AlertCircle className="h-5 w-5 text-[#FF5A5F]" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-xs uppercase tracking-wide text-[#FF5A5F]">Next up</p>
+                <p className="font-semibold text-[#FF5A5F] truncate">
                   {nextEventCountdown}: {firstEventTitle}
-                </span>
+                </p>
               </div>
             </div>
           )}
@@ -124,20 +130,19 @@ function UpcomingTab({ events, onSelectEvent }) {
       )}
 
       {filteredEvents.length === 0 ? (
-        <div className="text-center py-6 bg-gray-50 rounded-lg">
-          <CalendarClock className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-          <p className="text-gray-500">
-            {searchTerm ? "No events match your search." : "No upcoming events"}
-          </p>
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white/70 py-12 text-center">
+          <CalendarClock className="mx-auto mb-3 h-12 w-12 text-gray-300" />
+          <p className="text-sm text-gray-500">{searchTerm ? "No events match your search." : "No upcoming events"}</p>
         </div>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-6">
           {Object.entries(groupedEvents).map(([monthYear, monthEvents]) => (
             <div key={monthYear}>
-              <h3 className="text-sm font-medium text-gray-700 mb-2 pb-1 border-b">
+              <h3 className="mb-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <span className="h-1.5 w-1.5 rounded-full bg-[#FF5A5F]" />
                 {monthYear}
               </h3>
-              <div className="space-y-2">
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
                 {monthEvents.map(event => (
                   <EventPreviewCard
                     key={event.id}

--- a/src/components/UpcomingTab.js
+++ b/src/components/UpcomingTab.js
@@ -74,9 +74,9 @@ function UpcomingTab({ events, onSelectEvent }) {
   }, [firstEventDate]);
 
   return (
-    <div className="rounded-2xl border border-gray-200 bg-gradient-to-br from-white via-white to-gray-50 p-6 shadow-sm">
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <TabHeader
-        icon={<CalendarClock className="h-7 w-7 text-[#FF5A5F]" />}
+        icon={<CalendarClock className="h-7 w-7 text-sky-500" />}
         title="Upcoming Events"
       />
 
@@ -85,7 +85,7 @@ function UpcomingTab({ events, onSelectEvent }) {
         <input
           type="text"
           placeholder="Search events, people..."
-          className="w-full rounded-full border border-gray-200 bg-white/80 py-2.5 pl-12 pr-12 text-sm shadow-inner focus:border-[#FF5A5F] focus:outline-none focus:ring-2 focus:ring-[#FF5A5F]/30"
+          className="w-full rounded-full border border-slate-200 bg-white py-2.5 pl-12 pr-12 text-sm focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
         />
@@ -102,25 +102,25 @@ function UpcomingTab({ events, onSelectEvent }) {
 
       {(events || []).length > 0 && (
         <div className="mb-6 grid gap-3 text-sm sm:grid-cols-2">
-          <div className="flex items-center gap-3 rounded-xl border border-rose-100 bg-rose-50 px-4 py-3 shadow-inner">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-100">
-              <CheckCircle className="h-5 w-5 text-rose-500" />
+          <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+              <CheckCircle className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-rose-500">Pipeline</p>
-              <p className="font-semibold text-gray-700">{(events || []).length} upcoming {(events || []).length === 1 ? 'event' : 'events'}</p>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Pipeline</p>
+              <p className="font-semibold text-slate-700">{(events || []).length} upcoming {(events || []).length === 1 ? 'event' : 'events'}</p>
             </div>
           </div>
 
           {/* Adjusted to use firstEventTitle which checks for eventName first */}
           {firstEventDate && sortedEvents.length > 0 && (
-            <div className="flex items-center gap-3 rounded-xl border border-rose-100 bg-rose-50 px-4 py-3 shadow-inner">
-              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-100">
-                <AlertCircle className="h-5 w-5 text-rose-500" />
+            <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white text-sky-500">
+                <AlertCircle className="h-5 w-5" />
               </div>
               <div className="min-w-0">
-                <p className="text-xs uppercase tracking-wide text-rose-500">Next up</p>
-                <p className="font-semibold text-rose-500 truncate">
+                <p className="text-xs uppercase tracking-wide text-slate-500">Next up</p>
+                <p className="font-semibold text-sky-600 truncate">
                   {nextEventCountdown}: {firstEventTitle}
                 </p>
               </div>
@@ -130,16 +130,16 @@ function UpcomingTab({ events, onSelectEvent }) {
       )}
 
       {filteredEvents.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-gray-200 bg-white/70 py-12 text-center">
-          <CalendarClock className="mx-auto mb-3 h-12 w-12 text-gray-300" />
-          <p className="text-sm text-gray-500">{searchTerm ? "No events match your search." : "No upcoming events"}</p>
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 py-12 text-center">
+          <CalendarClock className="mx-auto mb-3 h-12 w-12 text-slate-300" />
+          <p className="text-sm text-slate-500">{searchTerm ? "No events match your search." : "No upcoming events"}</p>
         </div>
       ) : (
         <div className="space-y-6">
           {Object.entries(groupedEvents).map(([monthYear, monthEvents]) => (
             <div key={monthYear}>
-              <h3 className="mb-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                <span className="h-1.5 w-1.5 rounded-full bg-[#FF5A5F]" />
+              <h3 className="mb-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <span className="h-1.5 w-1.5 rounded-full bg-sky-400" />
                 {monthYear}
               </h3>
               <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/src/components/UpcomingTab.js
+++ b/src/components/UpcomingTab.js
@@ -102,25 +102,25 @@ function UpcomingTab({ events, onSelectEvent }) {
 
       {(events || []).length > 0 && (
         <div className="mb-6 grid gap-3 text-sm sm:grid-cols-2">
-          <div className="flex items-center gap-3 rounded-xl border border-[#FF5A5F]/20 bg-[#FFF5F7] px-4 py-3 shadow-inner">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[#FF5A5F]/10">
-              <CheckCircle className="h-5 w-5 text-[#FF5A5F]" />
+          <div className="flex items-center gap-3 rounded-xl border border-rose-100 bg-rose-50 px-4 py-3 shadow-inner">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-100">
+              <CheckCircle className="h-5 w-5 text-rose-500" />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-[#FF5A5F]">Pipeline</p>
+              <p className="text-xs uppercase tracking-wide text-rose-500">Pipeline</p>
               <p className="font-semibold text-gray-700">{(events || []).length} upcoming {(events || []).length === 1 ? 'event' : 'events'}</p>
             </div>
           </div>
 
           {/* Adjusted to use firstEventTitle which checks for eventName first */}
           {firstEventDate && sortedEvents.length > 0 && (
-            <div className="flex items-center gap-3 rounded-xl border border-[#FF5A5F]/20 bg-[#FFF5F7] px-4 py-3 shadow-inner">
-              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[#FF5A5F]/10">
-                <AlertCircle className="h-5 w-5 text-[#FF5A5F]" />
+            <div className="flex items-center gap-3 rounded-xl border border-rose-100 bg-rose-50 px-4 py-3 shadow-inner">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-rose-100">
+                <AlertCircle className="h-5 w-5 text-rose-500" />
               </div>
               <div className="min-w-0">
-                <p className="text-xs uppercase tracking-wide text-[#FF5A5F]">Next up</p>
-                <p className="font-semibold text-[#FF5A5F] truncate">
+                <p className="text-xs uppercase tracking-wide text-rose-500">Next up</p>
+                <p className="font-semibold text-rose-500 truncate">
                   {nextEventCountdown}: {firstEventTitle}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- redesign the event preview card with a richer layout, chip badges, and payment alerts to make listings feel more polished
- refresh the upcoming, pending, and finished tabs with gradient panels, responsive grids, and updated summary tiles to remove excess whitespace
- restyle search fields and empty states so the three tabs share a cohesive, modern aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f02308d0833394fd6dd32625c671