### PR TITLE
Close cards after moving events between tabs

### DIFF
--- a/src/components/CalendarTab.js
+++ b/src/components/CalendarTab.js
@@ -200,9 +200,14 @@ function CalendarTab({ events = [], onEventClick, onEventUpdate }) {
     }
   }, [handleCloseEventPanel]);
 
-  const handlePanelCloseRequest = useCallback(() => {
+  const handlePanelCloseRequest = useCallback(async () => {
     if (eventCardRef.current && typeof eventCardRef.current.handleClose === 'function') {
-      eventCardRef.current.handleClose();
+      try {
+        await eventCardRef.current.handleClose();
+      } catch (err) {
+        console.error('Error closing event card:', err);
+        handleCloseEventPanel();
+      }
     } else {
       handleCloseEventPanel();
     }

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -232,29 +232,29 @@ function EventCard(props, ref) {
     }
   };
 
-  const internalSave = () => {
+  const internalSave = async () => {
     if (onSave) {
-      onSave(localEvent);
+      await onSave(localEvent);
       setIsDirty(false);
     }
   };
 
-  const internalClose = () => {
+  const internalClose = async () => {
     if (isDirty && onSave) {
-      internalSave();
+      await internalSave();
     }
     if (setActiveEvent) setActiveEvent(null);
   };
 
   useImperativeHandle(ref, () => ({
-    handleClose: internalClose,
+    handleClose: () => internalClose(),
     triggerSave: () => {
       if (isDirty) {
-        internalSave();
-      } else {
-        console.log('No changes to save.');
+        return internalSave();
       }
+      return Promise.resolve();
     },
+    getCurrentEvent: () => localEvent,
     isDirty: () => isDirty,
   }));
 

--- a/src/components/EventPreviewCard.js
+++ b/src/components/EventPreviewCard.js
@@ -44,11 +44,14 @@ function EventPreviewCard({ event, onClick, highlight }) {
   const chipColor = 'bg-indigo-500/10 text-indigo-600';
 
   const formattedTotal = formatCurrency(event.grandTotal || event.priceGiven);
+  const highlightStyles = highlight
+    ? `${hasPaymentIssue ? '' : 'border-indigo-200'} bg-indigo-50/40 shadow-md`
+    : '';
 
   return (
     <div
       className={`relative overflow-hidden rounded-xl border border-slate-200 bg-white transition-all duration-300 cursor-pointer shadow-sm hover:shadow-lg hover:-translate-y-0.5
-        ${highlight ? 'ring-2 ring-offset-2 ring-indigo-500/25' : ''}
+        ${highlightStyles}
         ${hasPaymentIssue ? 'border-rose-200' : ''}`}
       onClick={onClick}
     >


### PR DESCRIPTION
## Summary
- ensure moving events between statuses saves any edits and closes the App side panel
- expose async helpers from EventCard and update CalendarTab to await them when closing
- adjust Upcoming tab highlight styling to remove the outline effect

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98384824c83338e3c877c0a735026